### PR TITLE
temp fix for collision manager bug

### DIFF
--- a/Library/RSBot.Core/Components/CollisionManager.cs
+++ b/Library/RSBot.Core/Components/CollisionManager.cs
@@ -94,6 +94,10 @@ namespace RSBot.Core.Components
             var offsetSource = GetOffsetByRegionIndex(GetRegionIndexFromPosition(source));
             var offsetDestination = GetOffsetByRegionIndex(GetRegionIndexFromPosition(destination));
 
+            if(offsetSource.X == 1920 && offsetSource.Y == 1920 && 
+               offsetDestination.X == 1920 && offsetDestination.Y == 1920)
+                return false; // when source and destionation positions are x-y = 1920 its bugging
+
             //Position -> SharpDX.Point
             var pointSource = new Point
             {


### PR DESCRIPTION
If `offsetSource` and `offsetDestination` x-y value has 1920 same time, the `HasCollisionBetween` method always returning true.