### PR TITLE
FixCppBuildWarnings

### DIFF
--- a/Library/RSBot.Loader.Library/RSBot.Loader.Library.vcxproj
+++ b/Library/RSBot.Loader.Library/RSBot.Loader.Library.vcxproj
@@ -35,7 +35,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)Build</OutDir>
+    <OutDir>$(SolutionDir)Build\</OutDir>
     <TargetName>Loader</TargetName>
     <LibraryPath>..\..\Dependencies\native;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
@@ -57,10 +57,11 @@
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <AdditionalDependencies>detours.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>..\..\Dependencies\native;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix 3 types Cpp Build Warnings
----------------------------
Microsoft.CppBuild.targets(500,5): warning MSB8004: Output Directory does not end with a trailing slash.  This build instance will add the slash as it is required to allow proper evaluation of the Output Directory.
-
1>Previous IPDB not found, fall back to full compilation.
1>All 547 functions were compiled because no usable IPDB/IOBJ from previous compilation was found.
-
1>detours.lib(detours.obj) : warning LNK4099: PDB 'detours.pdb' was not found with 'detours.lib(detours.obj)' or at 'SDClowen\RSBot\Build\detours.pdb'; linking object as if no debug info
1>detours.lib(modules.obj) : warning LNK4099: PDB 'detours.pdb' was not found with 'detours.lib(modules.obj)' or at 'SDClowen\RSBot\Build\detours.pdb'; linking object as if no debug info
1>detours.lib(disasm.obj) : warning LNK4099: PDB 'detours.pdb' was not found with 'detours.lib(disasm.obj)' or at 'SDClowen\RSBot\Build\detours.pdb'; linking object as if no debug info
1>detours.lib(creatwth.obj) : warning LNK4099: PDB 'detours.pdb' was not found with 'detours.lib(creatwth.obj)' or at 'SDClowen\RSBot\Build\detours.pdb'; linking object as if no debug info