### PR TITLE
Fix translation and add item property window

### DIFF
--- a/Application/RSBot/Views/Main.Designer.cs
+++ b/Application/RSBot/Views/Main.Designer.cs
@@ -86,7 +86,7 @@ namespace RSBot.Views
             this.toolStripStatusLabel1,
             this.lblIngameStatus});
             this.stripStatus.LayoutStyle = System.Windows.Forms.ToolStripLayoutStyle.HorizontalStackWithOverflow;
-            this.stripStatus.Location = new System.Drawing.Point(5, 588);
+            this.stripStatus.Location = new System.Drawing.Point(5, 696);
             this.stripStatus.Name = "stripStatus";
             this.stripStatus.Size = new System.Drawing.Size(1022, 23);
             this.stripStatus.SizingGrip = false;
@@ -126,7 +126,7 @@ namespace RSBot.Views
             this.bottomPanel.Controls.Add(this.btnSave);
             this.bottomPanel.Controls.Add(this.btnStartStop);
             this.bottomPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.bottomPanel.Location = new System.Drawing.Point(5, 536);
+            this.bottomPanel.Location = new System.Drawing.Point(5, 644);
             this.bottomPanel.Name = "bottomPanel";
             this.bottomPanel.Size = new System.Drawing.Size(1022, 52);
             this.bottomPanel.TabIndex = 2;
@@ -192,7 +192,7 @@ namespace RSBot.Views
             this.pSidebar.Dock = System.Windows.Forms.DockStyle.Right;
             this.pSidebar.Location = new System.Drawing.Point(777, 31);
             this.pSidebar.Name = "pSidebar";
-            this.pSidebar.Size = new System.Drawing.Size(250, 505);
+            this.pSidebar.Size = new System.Drawing.Size(250, 613);
             this.pSidebar.TabIndex = 6;
             // 
             // picLogo
@@ -200,7 +200,7 @@ namespace RSBot.Views
             this.picLogo.Cursor = System.Windows.Forms.Cursors.Hand;
             this.picLogo.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.picLogo.Image = ((System.Drawing.Image)(resources.GetObject("picLogo.Image")));
-            this.picLogo.Location = new System.Drawing.Point(0, 411);
+            this.picLogo.Location = new System.Drawing.Point(0, 519);
             this.picLogo.Name = "picLogo";
             this.picLogo.Size = new System.Drawing.Size(250, 94);
             this.picLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
@@ -417,7 +417,7 @@ namespace RSBot.Views
             this.tabMain.Location = new System.Drawing.Point(5, 110);
             this.tabMain.Name = "tabMain";
             this.tabMain.SelectedIndex = 0;
-            this.tabMain.Size = new System.Drawing.Size(772, 426);
+            this.tabMain.Size = new System.Drawing.Size(772, 534);
             this.tabMain.TabIndex = 3;
             // 
             // topCharacter
@@ -435,7 +435,7 @@ namespace RSBot.Views
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(249)))), ((int)(((byte)(249)))), ((int)(((byte)(249)))));
-            this.ClientSize = new System.Drawing.Size(1032, 616);
+            this.ClientSize = new System.Drawing.Size(1032, 724);
             this.ControlBox = false;
             this.Controls.Add(this.tabMain);
             this.Controls.Add(this.topCharacter);

--- a/Application/RSBot/Views/Main.cs
+++ b/Application/RSBot/Views/Main.cs
@@ -53,6 +53,9 @@ namespace RSBot.Views
         /// <param name="index">The index.</param>
         private void SelectBotbase(int index)
         {
+            if (Kernel.Bot.Running)
+                return;
+
             if (menuBotbase.DropDownItems.Count <= index) return;
 
             var selectedBotbase = Kernel.BotbaseManager.Bots.ElementAt(index).Value;
@@ -61,19 +64,19 @@ namespace RSBot.Views
 
             selectedBotbase.Translate();
 
-            menuBotbase.Text = selectedBotbase.Info.DisplayName;
+            menuBotbase.Text =  selectedBotbase.Info.DisplayName;
             menuBotbase.Image = selectedBotbase.Info.Image;
             menuBotbase.Tag = selectedBotbase;
-            var tempHandle = tabMain.Handle; //Generate the handle for this bitch
+            _ = tabMain.Handle; //Generate the handle for the tab control
 
             if(Kernel.Bot?.Botbase != null)
                 tabMain.TabPages.RemoveByKey(Kernel.Bot.Botbase.Info.Name);
 
             //Add the tab to the tabcontrol
-            var tabPage = new TabPage(LanguageManager.GetLangBySpecificKey("RSBot.Default", "DisplayName"))
+            var tabPage = new TabPage(LanguageManager.GetLangBySpecificKey(selectedBotbase.Info.Name, "TabText"))
             {
                 Name = selectedBotbase.Info.Name,
-                Enabled = false
+                Enabled = false,
             };
             
             tabPage.BackColor = Color.FromArgb(200, BackColor);
@@ -143,7 +146,7 @@ namespace RSBot.Views
 
             foreach (var extension in extensions.Where(extension => !extension.Value.Information.DisplayAsTab))
             {
-                var menuItem = new ToolStripMenuItem(extension.Value.Information.DisplayName)
+                var menuItem = new ToolStripMenuItem(LanguageManager.GetLangBySpecificKey(extension.Value.Information.InternalName, "DisplayName"))
                 {
                     Enabled = !extension.Value.Information.RequireIngame
                 };
@@ -363,14 +366,6 @@ namespace RSBot.Views
 
             if (!Kernel.Bot.Running)
             {
-                var xsec = PlayerConfig.Get<float>("RSBot.Area.X", 0) != 0;
-                var ysec = PlayerConfig.Get<float>("RSBot.Area.Y", 0) != 0;
-                if (!xsec && !ysec)
-                {
-                    Log.WarnLang("ConfigureTrainingAreaBeforeStartBot");
-                    return;
-                }
-
                 Kernel.Bot.Start();
 
                 BotWindow.SetStatusTextLang("Running");

--- a/Botbases/RSBot.Bot.Default/Bootstrap.cs
+++ b/Botbases/RSBot.Bot.Default/Bootstrap.cs
@@ -85,6 +85,16 @@ namespace RSBot.Bot.Default
         /// </summary>
         public void Start()
         {
+            var xsec = PlayerConfig.Get<float>("RSBot.Area.X", 0) != 0;
+            var ysec = PlayerConfig.Get<float>("RSBot.Area.Y", 0) != 0;
+            if (!xsec && !ysec)
+            {
+                Log.WarnLang("ConfigureTrainingAreaBeforeStartBot");
+                Kernel.Bot.Stop();
+
+                return;
+            }
+
             Bundles.Reload();
             Container.Bot = new Botbase();
 

--- a/Botbases/RSBot.Bot.Default/Bundle/PartyBuffing/PartyBuffingBundle.cs
+++ b/Botbases/RSBot.Bot.Default/Bundle/PartyBuffing/PartyBuffingBundle.cs
@@ -1,13 +1,10 @@
 ﻿using RSBot.Core;
 using RSBot.Core.Components;
 using RSBot.Core.Event;
-using RSBot.Core.Extensions;
-using RSBot.Core.Objects;
 using RSBot.Core.Objects.Party;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace RSBot.Bot.Default.Bundle.PartyBuffing
 {
@@ -63,14 +60,14 @@ namespace RSBot.Bot.Default.Bundle.PartyBuffing
                 var buffingMember = BuffingPartyMembers.Find(p => p.Name == member.Name);
                 if (buffingMember == null)
                     continue;
-                
-                if(buffingMember.Buffs.Count == 0)
+
+                if (buffingMember.Buffs.Count == 0)
                     continue;
 
                 var activeBuffs = member.Player.State.ActiveBuffs;
 
                 var neededBuffs = buffingMember.Buffs
-                    .Where(skillId => !activeBuffs.Any(p => p.Id == skillId || 
+                    .Where(skillId => !activeBuffs.Any(p => p.Id == skillId ||
                     (Game.ReferenceManager.SkillData.TryGetValue(skillId, out var refSkill) && refSkill.Action_Overlap == p.Record.Action_Overlap)));
 
                 foreach (var castingBuffId in neededBuffs)

--- a/Dependencies/Languages/RSBot.Default/Deutsch.rsl
+++ b/Dependencies/Languages/RSBot.Default/Deutsch.rsl
@@ -1,4 +1,5 @@
-DisplayName="Ausbildung"
+DisplayName="Training"
+TabText="Training"
 RSBot.Default.Main.GroupBox.checkUseSpeedDrug="Benutze Geschwindigkeitstrank"
 RSBot.Default.Main.GroupBox.checkCastBuffs="Cast buffs"
 RSBot.Default.Main.GroupBox.checkUseMount="Benutze Reittier wenn verfügbar"

--- a/Dependencies/Languages/RSBot.Default/English.rsl
+++ b/Dependencies/Languages/RSBot.Default/English.rsl
@@ -1,4 +1,5 @@
 DisplayName="Training"
+TabText="Training"
 RSBot.Default.Main.GroupBox.checkUseSpeedDrug="Use speed drug"
 RSBot.Default.Main.GroupBox.checkCastBuffs="Cast buffs"
 RSBot.Default.Main.GroupBox.checkUseMount="Use mount if available"

--- a/Dependencies/Languages/RSBot.Default/Español.rsl
+++ b/Dependencies/Languages/RSBot.Default/Español.rsl
@@ -1,4 +1,5 @@
 DisplayName="Entrenamiento"
+TabText="Entrenamiento"
 RSBot.Default.Main.GroupBox.checkUseSpeedDrug="Usar Drogas de Velocidad"
 RSBot.Default.Main.GroupBox.checkCastBuffs="Usar Buffs"
 RSBot.Default.Main.GroupBox.checkUseMount="Usar Caballo Disponible"

--- a/Dependencies/Languages/RSBot.Default/Tiếng Việt.rsl
+++ b/Dependencies/Languages/RSBot.Default/Tiếng Việt.rsl
@@ -1,4 +1,5 @@
 DisplayName="Khu Vực Luyện"
+TabText="Khu Vực Luyện"
 RSBot.Default.Main.GroupBox.checkUseSpeedDrug="Sử dụng chân chạy nhanh"
 RSBot.Default.Main.GroupBox.checkCastBuffs="Sử dụng kỹ năng hỗ trợ"
 RSBot.Default.Main.GroupBox.checkUseMount="Sử dụng ngựa nếu có"

--- a/Dependencies/Languages/RSBot.Default/Türkçe.rsl
+++ b/Dependencies/Languages/RSBot.Default/Türkçe.rsl
@@ -1,4 +1,5 @@
 DisplayName="Kasma"
+TabText="Kasma"
 RSBot.Default.Main.GroupBox.checkUseSpeedDrug="Hızlı Koşma Kullan"
 RSBot.Default.Main.GroupBox.checkCastBuffs="Skill Kullan"
 RSBot.Default.Main.GroupBox.checkUseMount="Binek varsa kullan"

--- a/Library/RSBot.Core/Bot.cs
+++ b/Library/RSBot.Core/Bot.cs
@@ -38,7 +38,7 @@ namespace RSBot.Core
             Botbase = botBase;
             Botbase.Initialize();
 
-            EventManager.FireEvent("OnSetBotbase");
+            EventManager.FireEvent("OnSetBotbase", botBase);
         }
 
         /// <summary>

--- a/Library/RSBot.Core/LanguageManager.cs
+++ b/Library/RSBot.Core/LanguageManager.cs
@@ -103,7 +103,7 @@ namespace RSBot.Core
         /// <param name="file">The language file path</param>
         /// <param name="controls">The controls</param>
         /// <param name="languages">the parsed languages list</param>
-        private static void CheckMissings(string file, string header, Control main, Dictionary<string, string> languages)
+        private static void CheckMissings(string file, string header, Control main, LangDict languages)
         {
             var contents = new List<string>();
 

--- a/Library/RSBot.Core/Objects/Spawn/SpawnedBionic.cs
+++ b/Library/RSBot.Core/Objects/Spawn/SpawnedBionic.cs
@@ -54,7 +54,7 @@ namespace RSBot.Core.Objects.Spawn
             Id = objId;
 
             if (Record != null)
-            Health = Record.MaxHealth;
+                Health = Record.MaxHealth;
         }
 
         /// <summary>

--- a/Library/RSBot.Core/Objects/Spawn/SpawnedBionic.cs
+++ b/Library/RSBot.Core/Objects/Spawn/SpawnedBionic.cs
@@ -52,6 +52,8 @@ namespace RSBot.Core.Objects.Spawn
         public SpawnedBionic(uint objId)
         {
             Id = objId;
+
+            if (Record != null)
             Health = Record.MaxHealth;
         }
 

--- a/Plugins/RSBot.Inventory/RSBot.Inventory.csproj
+++ b/Plugins/RSBot.Inventory/RSBot.Inventory.csproj
@@ -46,6 +46,12 @@
     <Compile Include="Bootstrap.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Subscriber\BuyItemSubscriber.cs" />
+    <Compile Include="Views\ItemProperties.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Views\ItemProperties.Designer.cs">
+      <DependentUpon>ItemProperties.cs</DependentUpon>
+    </Compile>
     <Compile Include="Views\Main.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -68,6 +74,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Views\ItemProperties.resx">
+      <DependentUpon>ItemProperties.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Views\Main.resx">
       <DependentUpon>Main.cs</DependentUpon>
     </EmbeddedResource>

--- a/Plugins/RSBot.Inventory/Views/ItemProperties.Designer.cs
+++ b/Plugins/RSBot.Inventory/Views/ItemProperties.Designer.cs
@@ -1,0 +1,72 @@
+﻿namespace RSBot.Inventory.Views
+{
+    partial class ItemProperties
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.propItem = new System.Windows.Forms.PropertyGrid();
+            this.SuspendLayout();
+            // 
+            // propItem
+            // 
+            this.propItem.BackColor = System.Drawing.SystemColors.Control;
+            this.propItem.CategoryForeColor = System.Drawing.SystemColors.ActiveCaption;
+            this.propItem.CategorySplitterColor = System.Drawing.SystemColors.ControlDark;
+            this.propItem.CommandsBackColor = System.Drawing.SystemColors.ControlDark;
+            this.propItem.DisabledItemForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
+            this.propItem.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.propItem.HelpBackColor = System.Drawing.SystemColors.ControlDark;
+            this.propItem.HelpVisible = false;
+            this.propItem.LineColor = System.Drawing.SystemColors.WindowFrame;
+            this.propItem.Location = new System.Drawing.Point(0, 0);
+            this.propItem.Name = "propItem";
+            this.propItem.SelectedItemWithFocusBackColor = System.Drawing.SystemColors.GradientActiveCaption;
+            this.propItem.SelectedItemWithFocusForeColor = System.Drawing.SystemColors.GrayText;
+            this.propItem.Size = new System.Drawing.Size(607, 693);
+            this.propItem.TabIndex = 0;
+            this.propItem.ViewBackColor = System.Drawing.SystemColors.InfoText;
+            this.propItem.ViewForeColor = System.Drawing.SystemColors.HighlightText;
+            // 
+            // ItemProperties
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(16F, 31F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.SystemColors.Control;
+            this.ClientSize = new System.Drawing.Size(607, 693);
+            this.Controls.Add(this.propItem);
+            this.Name = "ItemProperties";
+            this.Text = "ItemProperties";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.PropertyGrid propItem;
+    }
+}

--- a/Plugins/RSBot.Inventory/Views/ItemProperties.cs
+++ b/Plugins/RSBot.Inventory/Views/ItemProperties.cs
@@ -1,0 +1,290 @@
+﻿using RSBot.Core;
+using RSBot.Core.Client.ReferenceObjects;
+using RSBot.Core.Objects;
+using RSBot.Core.Objects.Item;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace RSBot.Inventory.Views
+{
+    public partial class ItemProperties : Form
+    {
+        #region Properties
+
+        public InventoryItem InventoryItem { get; }
+
+        #endregion Properties
+
+        #region Constructor
+
+        public ItemProperties(InventoryItem inventoryItem)
+        {
+            InitializeComponent();
+
+            InventoryItem = inventoryItem;
+            Text = $"Item properties - {InventoryItem.Record.GetRealName()} [Id: {InventoryItem.Record.ID}, TID2: {InventoryItem.Record.TypeID2}, TID3: {InventoryItem.Record.TypeID3}, TID4: {InventoryItem.Record.TypeID4}]";
+            Size = new Size(620, 800);
+
+            try
+            {
+                var iconImage = InventoryItem.Record.GetIcon();
+                var iconBitmap = new Bitmap(iconImage);
+                var iconHandle = iconBitmap.GetHicon();
+
+                Icon = Icon.FromHandle(iconHandle);
+            }
+            catch
+            {
+                ShowIcon = false;
+            }
+
+            propItem.SelectedObject = new ItemDebugInformation(InventoryItem);
+        }
+
+        #endregion Constructor
+    }
+
+    internal class ItemDebugInformation
+    {
+        [Category("RefObjItem")]
+        public int MaxStack { get; private set; }
+
+        [Category("RefObjItem")]
+        public byte ReqGender { get; private set; }
+
+        [Category("RefObjItem")]
+        public int ReqStr { get; private set; }
+
+        [Category("RefObjItem")]
+        public int ReqInt { get; private set; }
+
+        [Category("RefObjItem")]
+        public byte ItemClass { get; private set; }
+
+        [Category("RefObjItem")]
+        public byte Quivered { get; private set; }
+
+        [Category("RefObjItem")]
+        public byte SpeedClass { get; private set; }
+
+        [Category("RefObjItem")]
+        public byte TwoHanded { get; private set; }
+
+        [Category("RefObjItem")]
+        public short Range { get; private set; }
+
+        [Category("RefObjItem")]
+        public int Param1 { get; private set; }
+
+        [Category("RefObjItem")]
+        public int Param2 { get; private set; }
+
+        [Category("RefObjItem")]
+        public int Param3 { get; private set; }
+
+        [Category("RefObjItem")]
+        public int Param4 { get; private set; }
+
+        [Category("RefObjItem")]
+        public string Desc1 { get; private set; }
+
+        [Category("RefObjItem")]
+        public string Desc2 { get; private set; }
+
+        [Category("RefObjItem")]
+        public string Desc3 { get; private set; }
+
+        [Category("RefObjItem")]
+        public string Desc4 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte TypeID1 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte TypeID2 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte TypeID3 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte TypeID4 { get; private set; }
+
+        [Category("RefObjItem")]
+        public bool IsEquip => TypeID2 == 1;
+
+        [Category("RefObjItem")]
+        public bool IsJobEquip => TypeID2 == 1 && TypeID3 == 7;
+
+        [Category("RefObjItem")]
+        public bool IsStackable => TypeID2 == 3;
+
+        [Category("RefObjItem")]
+        public bool IsGold => IsStackable && TypeID3 == 5 && TypeID4 == 0;
+
+        [Category("RefObjItem")]
+        public bool IsTrading => IsStackable && TypeID3 == 8;
+
+        [Category("RefObjItem")]
+        public bool IsQuest => IsStackable && TypeID3 == 9;
+
+        [Category("RefObjItem")]
+        public bool IsSkillItem => IsStackable && TypeID3 == 13 && TypeID4 == 1;
+
+        [Category("RefObjItem")]
+        public int Degree => (ItemClass - 1) / 3 + 1;
+
+        [Category("RefObjItem")]
+        public int DegreeOffset => ItemClass - 3 * ((ItemClass - 1) / 3) - 1; //sro_client.sub_8BA6E0
+
+        [Category("InventoryItem")]
+        public byte OptLevel { get; private set; }
+
+        [Category("InventoryItem")]
+        public ulong Variance { get; private set; }
+
+        [Category("InventoryItem")]
+        public uint Durability { get; private set; }
+
+        [Category("InventoryItem")]
+        public List<MagicOptionInfo> MagicOptions { get; private set; }
+
+        [Category("InventoryItem")]
+        public List<BindingOption> BindingOptions { get; private set; }
+
+        [Category("InventoryItem")]
+        public ushort Amount { get; private set; }
+
+        [Category("InventoryItem")]
+        public InventoryItemState State { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte Service { get; private set; }
+
+        [Category("RefObjCommon")]
+        public uint Id { get; private set; }
+
+        [Category("RefObjCommon")]
+        public string CodeName { get; private set; }
+
+        [Category("RefObjCommon")]
+        public string ObjName { get; private set; } //Korean -> Localize by NameStrID
+
+        [Category("RefObjCommon")]
+        public string NameStrID { get; private set; } //reference for ObjName localization (SN_CODENAME)
+
+        [Category("RefObjCommon")]
+        public byte CashItem { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte Bionic { get; private set; }
+
+        [Category("RefObjCommon")]
+        public int Tid
+        {
+            get
+            {
+                if (Game.ClientType > GameClientType.Vietnam)
+                    return CashItem | Bionic | TypeID1 << 4 | TypeID2 << 10 | (TypeID3 << 16) | (TypeID4 << 24);
+
+                return CashItem | Bionic | TypeID1 << 2 | TypeID2 << 5 | TypeID3 << 7 | TypeID4 << 11;
+            }
+        }
+
+        [Category("RefObjCommon")]
+        public ObjectCountry Country { get; private set; }
+
+        [Category("RefObjCommon")]
+        public ObjectRarity Rarity { get; private set; }
+
+        [Category("RefObjCommon")]
+        public ObjectReqLevelType ReqLevelType1 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte ReqLevel1 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public ObjectReqLevelType ReqLevelType2 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte ReqLevel2 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public ObjectReqLevelType ReqLevelType3 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte ReqLevel3 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public ObjectReqLevelType ReqLevelType4 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public byte ReqLevel4 { get; private set; }
+
+        [Category("RefObjCommon")]
+        public short Speed1 { get; private set; } //WalkSpeed
+
+        [Category("RefObjCommon")]
+        public short Speed2 { get; private set; } //RunSpeed
+
+        [Category("RefObjCommon")]
+        public string AssocFileIcon { get; private set; } //Icon
+
+        [Category("RefObjCommon")]
+        public Image Icon { get; private set; }
+
+        public ItemDebugInformation(InventoryItem item)
+        {
+            MaxStack = item.Record.MaxStack;
+            ReqGender = item.Record.ReqGender;
+            ReqStr = item.Record.ReqStr;
+            ReqInt = item.Record.ReqInt;
+            ItemClass = item.Record.ItemClass;
+            Quivered = item.Record.Quivered;
+            SpeedClass = item.Record.SpeedClass;
+            TwoHanded = item.Record.TwoHanded;
+            Range = item.Record.Range;
+            Param1 = item.Record.Param1;
+            Param2 = item.Record.Param2;
+            Param3 = item.Record.Param3;
+            Param4 = item.Record.Param4;
+            Desc1 = item.Record.Desc1;
+            Desc2 = item.Record.Desc2;
+            Desc3 = item.Record.Desc3;
+            Desc4 = item.Record.Desc4;
+            OptLevel = item.OptLevel;
+            Variance = item.Variance;
+            Durability = item.Durability;
+            MagicOptions = item.MagicOptions;
+            BindingOptions = item.BindingOptions;
+            Amount = item.Amount;
+            State = item.State;
+            TypeID1 = item.Record.TypeID1;
+            TypeID2 = item.Record.TypeID2;
+            TypeID3 = item.Record.TypeID3;
+            TypeID4 = item.Record.TypeID4;
+            Service = item.Record.Service;
+            Id = item.Record.ID;
+            CodeName = item.Record.CodeName;
+            ObjName = item.Record.ObjName;
+            NameStrID = item.Record.NameStrID;
+            CashItem = item.Record.CashItem;
+            Bionic = item.Record.Bionic;
+            Country = item.Record.Country;
+            Rarity = item.Record.Rarity;
+            ReqLevelType1 = item.Record.ReqLevelType1;
+            ReqLevel1 = item.Record.ReqLevel1;
+            ReqLevelType2 = item.Record.ReqLevelType2;
+            ReqLevel2 = item.Record.ReqLevel2;
+            ReqLevelType3 = item.Record.ReqLevelType3;
+            ReqLevel3 = item.Record.ReqLevel3;
+            ReqLevelType4 = item.Record.ReqLevelType4;
+            ReqLevel4 = item.Record.ReqLevel4;
+            Speed1 = item.Record.Speed1;
+            Speed2 = item.Record.Speed2;
+            AssocFileIcon = item.Record.AssocFileIcon;
+            Icon = item.Record.GetIcon();
+        }
+    }
+}

--- a/Plugins/RSBot.Inventory/Views/ItemProperties.resx
+++ b/Plugins/RSBot.Inventory/Views/ItemProperties.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Plugins/RSBot.Inventory/Views/Main.Designer.cs
+++ b/Plugins/RSBot.Inventory/Views/Main.Designer.cs
@@ -67,7 +67,7 @@
             "Storage"});
             this.comboInventoryType.Location = new System.Drawing.Point(73, 4);
             this.comboInventoryType.Name = "comboInventoryType";
-            this.comboInventoryType.Size = new System.Drawing.Size(186, 21);
+            this.comboInventoryType.Size = new System.Drawing.Size(186, 39);
             this.comboInventoryType.TabIndex = 1;
             this.comboInventoryType.SelectedIndexChanged += new System.EventHandler(this.comboInventoryType_SelectedIndexChanged);
             // 
@@ -90,7 +90,7 @@
             this.lblFreeSlots.AutoSize = true;
             this.lblFreeSlots.Location = new System.Drawing.Point(69, 3);
             this.lblFreeSlots.Name = "lblFreeSlots";
-            this.lblFreeSlots.Size = new System.Drawing.Size(13, 13);
+            this.lblFreeSlots.Size = new System.Drawing.Size(29, 31);
             this.lblFreeSlots.TabIndex = 4;
             this.lblFreeSlots.Text = "0";
             // 
@@ -119,6 +119,7 @@
             this.listViewMain.UseCompatibleStateImageBehavior = false;
             this.listViewMain.View = System.Windows.Forms.View.Details;
             this.listViewMain.SelectedIndexChanged += new System.EventHandler(this.listViewMain_SelectedIndexChanged);
+            this.listViewMain.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.listViewMain_MouseDoubleClick);
             // 
             // colName
             // 

--- a/Plugins/RSBot.Inventory/Views/Main.cs
+++ b/Plugins/RSBot.Inventory/Views/Main.cs
@@ -261,5 +261,14 @@ namespace RSBot.Inventory.Views
                 return;
             }*/
         }
+
+        private void listViewMain_MouseDoubleClick(object sender, MouseEventArgs e)
+        {
+            if (GlobalConfig.Get<bool>("RSBot.DebugEnvironment") == false || listViewMain.SelectedItems.Count <= 0)
+                return;
+
+            var itemForm = new ItemProperties(listViewMain.SelectedItems[0].Tag as InventoryItem);
+            itemForm.Show();
+        }
     }
 }


### PR DESCRIPTION
[Bugfix]
- Fix for the botbase tab translation
- Fix crash if a spawned bionic doesn't have a record

[Feature]
- Add new window "ItemProperties" to Inventory plugin
![image](https://user-images.githubusercontent.com/12081190/163939307-9d7ab708-0b3b-4286-ae93-6487e4ab6a5e.png)
If the config `RSBot.DebugEnvironment` is set to `true`, the user is able to double click on an inventory item to see all internal properties. This makes implementing new ItemFilters alot easier and faster.