### PR TITLE
[Feature] Warlock mode

### DIFF
--- a/Botbases/RSBot.Bot.Default/Bundle/Target/TargetBundle.cs
+++ b/Botbases/RSBot.Bot.Default/Bundle/Target/TargetBundle.cs
@@ -13,7 +13,7 @@ namespace RSBot.Bot.Default.Bundle.Target
         /// </summary>
         public void Invoke()
         {
-            if (Game.SelectedEntity != null && Game.SelectedEntity.State.LifeState == LifeState.Alive)
+            if (Game.SelectedEntity != null && Game.SelectedEntity.State.LifeState == LifeState.Alive && !Game.SelectedEntity.State.HasTwoDots())
                 return;
 
             var monster = GetNearestEnemy();
@@ -42,6 +42,7 @@ namespace RSBot.Bot.Default.Bundle.Target
         private SpawnedMonster GetNearestEnemy()
         {
             if (!SpawnManager.TryGetEntities<SpawnedMonster>(out var entities, m => m.State.LifeState == LifeState.Alive &&
+                            m.State.HasTwoDots() == false &&
                             m.IsBehindObstacle == false &&
                             !Bundles.Avoidance.AvoidMonster(m.Rarity) && 
                             m.DistanceToPlayer <= 40))

--- a/Botbases/RSBot.Bot.Default/Bundle/Target/TargetBundle.cs
+++ b/Botbases/RSBot.Bot.Default/Bundle/Target/TargetBundle.cs
@@ -13,7 +13,8 @@ namespace RSBot.Bot.Default.Bundle.Target
         /// </summary>
         public void Invoke()
         {
-            if (Game.SelectedEntity != null && Game.SelectedEntity.State.LifeState == LifeState.Alive && !Game.SelectedEntity.State.HasTwoDots())
+            bool warlockModeEnabled = PlayerConfig.Get<bool>("RSBot.Skills.WarlockMode", false);
+            if (Game.SelectedEntity != null && Game.SelectedEntity.State.LifeState == LifeState.Alive && !(warlockModeEnabled && Game.SelectedEntity.State.HasTwoDots()))
                 return;
 
             var monster = GetNearestEnemy();
@@ -41,8 +42,9 @@ namespace RSBot.Bot.Default.Bundle.Target
         /// <returns></returns>
         private SpawnedMonster GetNearestEnemy()
         {
+            bool warlockModeEnabled = PlayerConfig.Get<bool>("RSBot.Skills.WarlockMode", false);
             if (!SpawnManager.TryGetEntities<SpawnedMonster>(out var entities, m => m.State.LifeState == LifeState.Alive &&
-                            m.State.HasTwoDots() == false &&
+                            !(warlockModeEnabled && m.State.HasTwoDots()) &&
                             m.IsBehindObstacle == false &&
                             !Bundles.Avoidance.AvoidMonster(m.Rarity) && 
                             m.DistanceToPlayer <= 40))

--- a/Library/RSBot.Core/Objects/Skill/SkillInfo.cs
+++ b/Library/RSBot.Core/Objects/Skill/SkillInfo.cs
@@ -35,7 +35,15 @@ namespace RSBot.Core.Objects.Skill
         /// <value>
         ///   <c>true</c> if attack; otherwise, <c>false</c>.
         /// </value>
-        public bool IsAttack => Record.Params[1] == 6386804;
+        public bool IsAttack => Record.Params[1] == 6386804 || IsDot;
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="SkillInfo"/> is a DoT.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if DoT; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsDot => Record.Basic_Code.StartsWith("SKILL_EU_WARLOCK_DOTA");
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="SkillInfo"/> is imbue.
@@ -84,7 +92,7 @@ namespace RSBot.Core.Objects.Skill
         /// <value>
         /// <c>true</c> if this instance can be used; otherwise, <c>false</c>.
         /// </value>
-        public bool CanBeCasted => !CanNotBeCasted && !HasCooldown && Game.Player.Mana >= Record.Consume_MP;
+        public bool CanBeCasted => (IsDot || !CanNotBeCasted) && !HasCooldown && Game.Player.Mana >= Record.Consume_MP;
 
         /// <summary>
         /// Skill Token (using for buffs)

--- a/Library/RSBot.Core/Objects/State.cs
+++ b/Library/RSBot.Core/Objects/State.cs
@@ -171,5 +171,14 @@ namespace RSBot.Core.Objects
 
             return ActiveBuffs.Remove(removedBuff);
         }
+
+        /// <summary>
+        /// Checks two active DoTs.
+        /// </summary>
+        /// <returns></returns>
+        public bool HasTwoDots()
+        {
+            return ActiveBuffs.Where(b => b.IsDot).Count() >= 2;
+        }
     }
 }

--- a/Plugins/RSBot.Skills/Views/Main.Designer.cs
+++ b/Plugins/RSBot.Skills/Views/Main.Designer.cs
@@ -82,6 +82,8 @@
             this.colActiveName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.colActiveLevel = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.checkLearnMasteryBotStopped = new SDUI.Controls.CheckBox();
+            this.groupWarlockMode = new SDUI.Controls.GroupBox();
+            this.checkWarlockMode = new SDUI.Controls.CheckBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.tabControl1.SuspendLayout();
@@ -96,6 +98,7 @@
             this.skillContextMenu.SuspendLayout();
             this.panel1.SuspendLayout();
             this.tabPage4.SuspendLayout();
+            this.groupWarlockMode.SuspendLayout();
             this.SuspendLayout();
             // 
             // groupBox1
@@ -354,6 +357,7 @@
             // tabPage2
             // 
             this.tabPage2.BackColor = System.Drawing.Color.White;
+            this.tabPage2.Controls.Add(this.groupWarlockMode);
             this.tabPage2.Controls.Add(this.grpMasteryLearn);
             this.tabPage2.Controls.Add(this.groupBox3);
             this.tabPage2.Controls.Add(this.groupBox4);
@@ -710,6 +714,30 @@
             this.checkLearnMasteryBotStopped.Size = new System.Drawing.Size(156, 23);
             this.checkLearnMasteryBotStopped.TabIndex = 25;
             this.checkLearnMasteryBotStopped.Text = "Enabled if bot is stopped";
+            //
+            // groupWarlockMode
+            // 
+            this.groupWarlockMode.BackColor = System.Drawing.Color.Transparent;
+            this.groupWarlockMode.Controls.Add(this.checkWarlockMode);
+            this.groupWarlockMode.Location = new System.Drawing.Point(8, 350);
+            this.groupWarlockMode.Name = "groupWarlockMode";
+            this.groupWarlockMode.Padding = new System.Windows.Forms.Padding(3, 10, 3, 3);
+            this.groupWarlockMode.Radius = 2;
+            this.groupWarlockMode.Size = new System.Drawing.Size(367, 67);
+            this.groupWarlockMode.TabIndex = 14;
+            this.groupWarlockMode.TabStop = false;
+            this.groupWarlockMode.Text = "Warlock mode";
+            // 
+            // checkWarlockMode
+            // 
+            this.checkWarlockMode.BackColor = System.Drawing.Color.Transparent;
+            this.checkWarlockMode.Checked = false;
+            this.checkWarlockMode.Location = new System.Drawing.Point(86, 33);
+            this.checkWarlockMode.Name = "checkWarlockMode";
+            this.checkWarlockMode.Size = new System.Drawing.Size(163, 23);
+            this.checkWarlockMode.TabIndex = 0;
+            this.checkWarlockMode.Text = "Change target after 2 DoTs";
+            this.checkWarlockMode.CheckedChanged += new System.EventHandler(this.checkWarlockMode_CheckedChanged);
             // 
             // Main
             // 
@@ -738,6 +766,7 @@
             this.skillContextMenu.ResumeLayout(false);
             this.panel1.ResumeLayout(false);
             this.tabPage4.ResumeLayout(false);
+            this.groupWarlockMode.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -797,5 +826,7 @@
         private SDUI.Controls.ComboBox comboLearnMastery;
         private SDUI.Controls.CheckBox checkLearnMastery;
         private SDUI.Controls.CheckBox checkLearnMasteryBotStopped;
+        private SDUI.Controls.GroupBox groupWarlockMode;
+        private SDUI.Controls.CheckBox checkWarlockMode;
     }
 }

--- a/Plugins/RSBot.Skills/Views/Main.cs
+++ b/Plugins/RSBot.Skills/Views/Main.cs
@@ -105,6 +105,7 @@ namespace RSBot.Skills.Views
             checkBoxNoAttack.Checked = PlayerConfig.Get<bool>("RSBot.Skills.NoAttack");
             checkLearnMastery.Checked = PlayerConfig.Get<bool>("RSBot.Skills.learnMastery");
             numMasteryGap.Value = PlayerConfig.Get<byte>("RSBot.Skills.masteryGap", 0);
+            checkWarlockMode.Checked = PlayerConfig.Get<bool>("RSBot.Skills.WarlockMode", false);
         }
 
         /// <summary>
@@ -765,6 +766,11 @@ namespace RSBot.Skills.Views
             _selectedMastery = selectedItem;
 
             PlayerConfig.Set("RSBot.Skills.selectedMastery", selectedItem.Record.NameCode);
+        }
+
+        private void checkWarlockMode_CheckedChanged(object sender, EventArgs e)
+        {
+            PlayerConfig.Set("RSBot.Skills.WarlockMode", checkWarlockMode.Checked);
         }
     }
 }


### PR DESCRIPTION
- Added a new checkbox under advanced skill section:
![image](https://user-images.githubusercontent.com/19815169/166120676-be8e0428-0485-4167-b910-a528b6fc4e86.png)
- When warlock mode is active, bot will switch target when current target has at least 2 DoTs applied, and it will not select mobs that have at least 2 DoTs applied
- Warlock's DoT skills are now classified as attack skills and available in the skill selection list