### PR TITLE
[Feature] Store items from pet, shopping improvements

### DIFF
--- a/Library/RSBot.Core/Network/Handler/Agent/Inventory/InventoryOperationResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Inventory/InventoryOperationResponse.cs
@@ -243,7 +243,7 @@ namespace RSBot.Core.Network.Handler.Agent.Inventory
                 if (itemAtDestination.ItemId == itemAtSource.ItemId)
                 {
                     //Check if the items can stack, otherwise move A to B and B to A
-                    var newItemAmount = itemAtDestination.Amount + itemAtSource.Amount;
+                    var newItemAmount = itemAtDestination.Amount + amount;
                     if (newItemAmount > itemAtDestination.Record.MaxStack)
                     {
                         itemAtDestination.Slot = sourceSlot;
@@ -254,9 +254,10 @@ namespace RSBot.Core.Network.Handler.Agent.Inventory
                     else
                     {
                         itemAtDestination.Amount = (ushort)newItemAmount;
+                        itemAtSource.Amount -= amount;
 
                         Log.Debug($"[Inventory->Inventory] Merge item {itemAtSource.Record.GetRealName()} (slot={itemAtSource.Slot}, amount={itemAtSource.Amount}) with (slot={itemAtDestination.Slot}, amount={itemAtDestination.Amount})");
-                        Core.Game.Player.Inventory.RemoveItemAt(sourceSlot);
+                        if (itemAtSource.Amount <= 0) Core.Game.Player.Inventory.RemoveItemAt(sourceSlot);
                     }
                 }
                 else

--- a/Library/RSBot.Core/Objects/Cos/AbilityPet.cs
+++ b/Library/RSBot.Core/Objects/Cos/AbilityPet.cs
@@ -170,9 +170,9 @@ namespace RSBot.Core.Objects
         /// Moves the item to player.
         /// </summary>
         /// <param name="slot">The slot.</param>
-        public void MoveItemToPlayer(byte slot)
+        public byte? MoveItemToPlayer(byte slot)
         {
-            if (Game.Player.Inventory.Full) return;
+            if (Game.Player.Inventory.Full) return null;
 
             var destinationSlot = Game.Player.Inventory.GetFreeSlot();
 
@@ -185,6 +185,7 @@ namespace RSBot.Core.Objects
             var callback = new AwaitCallback(null, 0xB034);
             PacketManager.SendPacket(packet, PacketDestination.Server, callback);
             callback.AwaitResponse();
+            return destinationSlot;
         }
     }
 }

--- a/Plugins/RSBot.Shopping/Views/Main.Designer.cs
+++ b/Plugins/RSBot.Shopping/Views/Main.Designer.cs
@@ -144,6 +144,7 @@
             this.checkPickupRare = new SDUI.Controls.CheckBox();
             this.checkPickupGold = new SDUI.Controls.CheckBox();
             this.separator5 = new SDUI.Controls.Separator();
+            this.checkStoreItemsFromPet = new SDUI.Controls.CheckBox();
             this.contextShoppingList.SuspendLayout();
             this.contextAvailableProducts.SuspendLayout();
             this.tabMain.SuspendLayout();
@@ -246,6 +247,7 @@
             // 
             this.groupBox1.BackColor = System.Drawing.Color.Transparent;
             this.groupBox1.Controls.Add(this.checkSellItemsFromPet);
+            this.groupBox1.Controls.Add(this.checkStoreItemsFromPet);
             this.groupBox1.Controls.Add(this.checkRepairGear);
             this.groupBox1.Controls.Add(this.checkEnable);
             this.groupBox1.Dock = System.Windows.Forms.DockStyle.Bottom;
@@ -1338,6 +1340,18 @@
             this.separator5.Size = new System.Drawing.Size(730, 10);
             this.separator5.TabIndex = 9;
             this.separator5.Text = "separator5";
+            //
+            // checkStoreItemsFromPet
+            // 
+            this.checkStoreItemsFromPet.AutoSize = true;
+            this.checkStoreItemsFromPet.BackColor = System.Drawing.Color.Transparent;
+            this.checkStoreItemsFromPet.Checked = true;
+            this.checkStoreItemsFromPet.Location = new System.Drawing.Point(567, 33);
+            this.checkStoreItemsFromPet.Name = "checkStoreItemsFromPet";
+            this.checkStoreItemsFromPet.Size = new System.Drawing.Size(131, 15);
+            this.checkStoreItemsFromPet.TabIndex = 4;
+            this.checkStoreItemsFromPet.Text = "Store items from pet";
+            this.checkStoreItemsFromPet.CheckedChanged += new System.EventHandler(this.checkStoreItemsFromPet_CheckedChanged);
             // 
             // Main
             // 
@@ -1490,5 +1504,6 @@
         private SDUI.Controls.Separator separator1;
         private SDUI.Controls.Separator separator2;
         private SDUI.Controls.Separator separator5;
+        private SDUI.Controls.CheckBox checkStoreItemsFromPet;
     }
 }

--- a/Plugins/RSBot.Shopping/Views/Main.cs
+++ b/Plugins/RSBot.Shopping/Views/Main.cs
@@ -570,7 +570,7 @@ namespace RSBot.Shopping.Views
             checkPickupGold.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Gold", true);
             checkPickupRare.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Rare", true);
             checkEnableAbilityPet.Checked = PlayerConfig.Get("RSBot.Items.Pickup.EnableAbilityPet", true);
-            checkSellItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.SellPetItems", true);
+            checkStoreItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.StorePetItems", true);
             checkDontPickupInBerzerk.Checked = PlayerConfig.Get("RSBot.Items.Pickup.DontPickupInBerzerk", true);
             cbJustpickmyitems.Checked = PlayerConfig.Get("RSBot.Items.Pickup.JustPickMyItems", true);
             cbDontPickupWhileBotting.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.DontPickupWhileBotting");
@@ -578,6 +578,7 @@ namespace RSBot.Shopping.Views
             ShoppingManager.Enabled = checkEnable.Checked;
             ShoppingManager.RepairGear = checkRepairGear.Checked;
             ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
+            ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
 
             LoadShoppingList();
             LoadSellList();
@@ -594,6 +595,17 @@ namespace RSBot.Shopping.Views
         {
             PlayerConfig.Set("RSBot.Shopping.SellPetItems", checkSellItemsFromPet.Checked);
             ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
+        }
+
+        /// <summary>
+        /// Handles the CheckedChanged event of the checkStoreItemsFromPet control.
+        /// </summary>
+        /// <param name="sender">The source of the event.</param>
+        /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
+        private void checkStoreItemsFromPet_CheckedChanged(object sender, EventArgs e)
+        {
+            PlayerConfig.Set("RSBot.Shopping.StorePetItems", checkSellItemsFromPet.Checked);
+            ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
         }
 
         /// <summary>


### PR DESCRIPTION
- Added a new checkbox "Store items from pet" under Shopping tab's General Setup group:
![image](https://user-images.githubusercontent.com/19815169/166258168-d4a390ee-c317-4db2-8023-16c6880a5897.png)
- The checkbox modifies a new player config var "RSBot.Shopping.StorePetItems"
- When the config var is true and player has a grab pet summoned, items from pet's inventory that are set for storage will be stored
- Changed selling from pet logic: items will be moved to player and sold one by one to prevent a situation in which pet has more items than player's free inventory slots and not all items are sold
- Added item stack merging after buying
- Fixed invalid inventory update in following scenario:
Item x's max stack = 100
Item x in slot 1, amount 80
Item x in slot 2, amount 40
Move from slot 2 to slot 1, amount 20
Result before fix:
Item x in slot 1, amount 100
Item x in slot 2 removed
Result after fix:
Item x in slot 1, amount 100
Item x in slot 2, amount 20