### PR TITLE
Fixed issue #5

### DIFF
--- a/Library/RSBot.Core/Objects/Player.cs
+++ b/Library/RSBot.Core/Objects/Player.cs
@@ -642,14 +642,14 @@ namespace RSBot.Core.Objects
                     if (record.Param1 > 0 || record.Param3 > 0)
                     {
                         if (Race == ObjectCountry.Chinese)
-                            duration = 1000;
+                            duration = 1050;
                         else
-                            duration = 15000;
+                            duration = 15050;
                     }
                     // grain
                     else if (record.Param2 > 0 || record.Param4 > 0)
                     {
-                        duration = 4000;
+                        duration = 4050;
                     }
                 }
                 var elapsed = Environment.TickCount - tick;
@@ -699,7 +699,7 @@ namespace RSBot.Core.Objects
                 return false;
 
             var elapsed = Environment.TickCount - _lastUniversalPillTick;
-            if (elapsed < 1000)
+            if (elapsed < 1050)
                 return false;
 
             var typeIdFilter = new TypeIdFilter(3, 3, 2, 6);
@@ -724,7 +724,7 @@ namespace RSBot.Core.Objects
                 return false;
 
             var elapsed = Environment.TickCount - _lastPurificationPillTick;
-            if (elapsed < 20000)
+            if (elapsed < 20050)
                 return false;
 
             var typeIdFilter = new TypeIdFilter(3, 3, 2, 1);

--- a/Plugins/RSBot.Protection/Components/Player/UniversalPillHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Player/UniversalPillHandler.cs
@@ -1,5 +1,6 @@
 ﻿using RSBot.Core;
 using RSBot.Core.Event;
+using RSBot.Core.Objects;
 
 namespace RSBot.Protection.Components.Player
 {
@@ -18,8 +19,38 @@ namespace RSBot.Protection.Components.Player
         /// </summary>
         private static void SubscribeEvents()
         {
-            EventManager.SubscribeEvent("OnPlayerBadEffect", OnPlayerBadEffect);
+            EventManager.SubscribeEvent("OnTick", OnPlayerBadEffect);
         }
+
+        /// <summary>
+        /// Bad effects curable by universal pills.
+        /// </summary>
+        private static readonly BadEffect universalPillEffects =
+            BadEffect.Frozen |
+            BadEffect.Frostbitten |
+            BadEffect.Shocked |
+            BadEffect.Burnt |
+            BadEffect.Poisoned |
+            BadEffect.Zombie;
+
+        /// <summary>
+        /// Bad effects curable by purification pills.
+        /// </summary>
+        private static readonly BadEffect purificationPillEffects =
+            BadEffect.Sleep |
+            BadEffect.Bind |
+            BadEffect.Dull |
+            BadEffect.Fear |
+            BadEffect.ShortSighted |
+            BadEffect.Bleed |
+            BadEffect.Darkness |
+            BadEffect.Disease |
+            BadEffect.Decay |
+            BadEffect.Weak |
+            BadEffect.Impotent |
+            BadEffect.Division |
+            BadEffect.Panic |
+            BadEffect.Hidden;
 
         /// <summary>
         /// Cores the on player bad effect.
@@ -29,7 +60,16 @@ namespace RSBot.Protection.Components.Player
             var useUniversalPill = PlayerConfig.Get<bool>("RSBot.Protection.checkUseUniversalPills", true);
 
             if (useUniversalPill)
-                Game.Player.UseUniversalPill();
+            {
+                if ((Game.Player.BadEffect & universalPillEffects) != 0)
+                {
+                    Game.Player.UseUniversalPill();
+                }
+                else if ((Game.Player.BadEffect & purificationPillEffects) != 0)
+                {
+                    Game.Player.UsePurificationPill();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Universal and purification pills are now used based on bad effect detected on player character
- Bad status detection now runs on OnTick event, so pills can be used on cooldown while player has multiple bad statuses in effect 
- Slightly increased internal potion and pill cooldowns to prevent potions / pills being used before cooldown