### PR TITLE
[Bugfix] Fix crash in RSBot.Shopping if the refItem could not be found

### DIFF
--- a/Application/RSBot/Views/Main.cs
+++ b/Application/RSBot/Views/Main.cs
@@ -85,7 +85,7 @@ namespace RSBot.Views
 
             tabMain.TabPages.Insert(1, tabPage);
 
-            Kernel.Bot.SetBotbase(selectedBotbase);
+            Kernel.Bot?.SetBotbase(selectedBotbase);
             GlobalConfig.Set("RSBot.BotIndex", index.ToString());
 
             if (Game.Player == null)
@@ -122,7 +122,7 @@ namespace RSBot.Views
 
                 var tabPage = new TabPage
                 {
-                    Text = LanguageManager.GetLangBySpecificKey(extension.Value.Information.InternalName, "DisplayName"),
+                    Text = LanguageManager.GetLangBySpecificKey(extension.Value.Information.InternalName, "DisplayName", extension.Value.Information.DisplayName),
                     Enabled = !extension.Value.Information.RequireIngame,
                     Name = extension.Value.Information.InternalName
                 };
@@ -156,7 +156,8 @@ namespace RSBot.Views
 
             foreach (var extension in extensions.Where(extension => !extension.Value.Information.DisplayAsTab))
             {
-                var menuItem = new ToolStripMenuItem(LanguageManager.GetLangBySpecificKey(extension.Value.Information.InternalName, "DisplayName"))
+                var menuItemText = LanguageManager.GetLangBySpecificKey(extension.Value.Information.InternalName, "DisplayName", extension.Value.Information.DisplayName);
+                var menuItem = new ToolStripMenuItem(menuItemText)
                 {
                     Enabled = !extension.Value.Information.RequireIngame
                 };
@@ -210,7 +211,7 @@ namespace RSBot.Views
         /// <exception cref="System.NotImplementedException"></exception>
         private void PluginMenuItem_Click(object sender, EventArgs e)
         {
-            var menuItem = (MenuItem)sender;
+            var menuItem = (ToolStripMenuItem)sender;
             var plugin = (IPlugin)menuItem.Tag;
 
             var window = new Form()

--- a/Library/RSBot.Core/LanguageManager.cs
+++ b/Library/RSBot.Core/LanguageManager.cs
@@ -197,12 +197,13 @@ namespace RSBot.Core
         /// Get language value
         /// </summary>
         /// <param name="key">The key</param>
-        public static string GetLangBySpecificKey(string parent, string key)
+        /// <param name="default">The default value that will be returned if the translation could not be found</param>
+        public static string GetLangBySpecificKey(string parent, string key, string @default = "")
         {
             if (_values.ContainsKey(parent) && _values[parent].ContainsKey(key))
                 return _values[parent][key];
 
-            return string.Empty;
+            return @default;
         }
 
         /// <summary>

--- a/Plugins/RSBot.Shopping/Views/Main.cs
+++ b/Plugins/RSBot.Shopping/Views/Main.cs
@@ -128,6 +128,9 @@ namespace RSBot.Shopping.Views
                     var refPackageItem = Game.ReferenceManager.GetRefPackageItem(good.RefPackageItemCodeName);
                     var item = Game.ReferenceManager.GetRefItem(refPackageItem.RefItemCodeName);
 
+                    if (item == null)
+                        continue;
+
                     if (!checkShowEquipment.Checked && item.TypeID2 == 1)
                         continue;
 


### PR DESCRIPTION
[Bugfix]
* Fix crash in RSBot.Shopping if the refItem could not be found
* Fix crash for plugins which are not being displayed as tab page (see image to get what I mean)
![image](https://user-images.githubusercontent.com/12081190/166718764-48eaba4b-2ceb-4ea2-8a8d-2828b42b2746.png)
* Fix botbase and plugin name display if the translation was not found