### PR TITLE
[Feature] Mbot script format support, script behavior improvements

### DIFF
--- a/Botbases/RSBot.Bot.Default/Bot/Botbase.cs
+++ b/Botbases/RSBot.Bot.Default/Bot/Botbase.cs
@@ -60,9 +60,7 @@ namespace RSBot.Bot.Default.Bot
 
             if (Bundles.Loop.Config.UseSpeedDrug && Game.Player.State.ActiveBuffs.FindIndex(p => p.Record.Action_Overlap == 6) < 0)
             {
-                var item = Game.Player.Inventory.GetItems(new TypeIdFilter(3, 3, 13, 1)).Find(p => p.Record.Desc1.Contains("_SPEED_"));
-                if (item != null)
-                    item.Use();
+               Game.Player.UseSpeedDrug();
             }
 
             var noAttack = PlayerConfig.Get("RSBot.Skills.NoAttack", false);

--- a/Botbases/RSBot.Bot.Default/Bundle/Buff/BuffBundle.cs
+++ b/Botbases/RSBot.Bot.Default/Bundle/Buff/BuffBundle.cs
@@ -1,6 +1,4 @@
-﻿using RSBot.Core;
-using RSBot.Core.Components;
-using RSBot.Core.Objects;
+﻿using RSBot.Core.Components;
 
 namespace RSBot.Bot.Default.Bundle.Buff
 {
@@ -11,22 +9,7 @@ namespace RSBot.Bot.Default.Bundle.Buff
         /// </summary>
         public void Invoke()
         {
-            while (true)
-            {
-                if (Game.Player.State.LifeState != LifeState.Alive)
-                    break;
-
-                var buff = SkillManager.Buffs.Find(p => !Game.Player.State.HasActiveBuff(p, out _) && p.CanBeCasted);
-                if (buff == null)
-                    break;
-
-                var playerSkill = Game.Player.Skills.GetSkillInfoById(buff.Id);
-                if (playerSkill == null)
-                    continue;
-
-                Log.Debug($"Trying to cast buff: {buff} {buff.Record.Basic_Code}");
-                SkillManager.CastBuff(buff);
-            }
+            SkillManager.CastBuffs();
         }
 
         /// <summary>

--- a/Botbases/RSBot.Bot.Default/Bundle/Loop/LoopBundle.cs
+++ b/Botbases/RSBot.Bot.Default/Bundle/Loop/LoopBundle.cs
@@ -47,10 +47,6 @@ namespace RSBot.Bot.Default.Bundle.Loop
                 //Wait for the vehicle to spawn
                 Thread.Sleep(1000);
             }
-
-            //We don't need to use buffs in town...
-            if (Config.CastBuffs && !TownscriptRunning)
-                Bundles.Buff.Invoke();
         }
 
         /// <summary>
@@ -124,7 +120,7 @@ namespace RSBot.Bot.Default.Bundle.Loop
             Log.NotifyLang("LoadingWalkScript", Config.WalkScript);
 
             ScriptManager.Load(Config.WalkScript);
-            ScriptManager.RunScript();
+            ScriptManager.RunScript(Config.CastBuffs);
         }
     }
 }

--- a/Botbases/RSBot.Bot.Default/Views/Main.cs
+++ b/Botbases/RSBot.Bot.Default/Views/Main.cs
@@ -133,7 +133,7 @@ namespace RSBot.Bot.Default.Views
         {
             var diag = new OpenFileDialog
             {
-                Filter = @"RSBot Bot script|*.rbs",
+                Filter = @"RSBot Bot script|*.rbs|mBot script|*.txt",
                 Title = @"Browse for a walkback script"
             };
 

--- a/Library/RSBot.Core/Components/IScriptParser.cs
+++ b/Library/RSBot.Core/Components/IScriptParser.cs
@@ -1,0 +1,14 @@
+﻿using RSBot.Core.Objects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Components
+{
+    internal interface IScriptParser
+    {
+        ScriptCommand[] ParseCommands(string[] commands);
+    }
+}

--- a/Library/RSBot.Core/Components/MbotScriptParser.cs
+++ b/Library/RSBot.Core/Components/MbotScriptParser.cs
@@ -1,0 +1,87 @@
+﻿using RSBot.Core.Objects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Components
+{
+    internal class MbotScriptParser : IScriptParser
+    {
+        public ScriptCommand[] ParseCommands(string[] commands)
+        {
+            List<ScriptCommand> result = new List<ScriptCommand>();
+            foreach(var command in commands)
+            {
+                result.Add(ParseCommand(command));
+            }
+            return result.ToArray();
+        }
+
+        private ScriptCommand ParseCommand(string command)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                Log.Notify($"Empty script command");
+                return new ScriptCommand { Type = ScriptCommandType.Unknown };
+            }
+
+            var cmdTrimmed = command.Trim().ToLower();
+            if(cmdTrimmed.StartsWith("go"))
+            {
+                var dungeonRegex = new Regex(@"\D(-*\d+),(-*\d+),(-*\d+)[\s\S]*");
+                var dungeonMatch = dungeonRegex.Match(cmdTrimmed);
+                if (dungeonMatch.Success)
+                {
+                    if(float.TryParse(dungeonMatch.Groups[1].Value, out float x) &&
+                        float.TryParse(dungeonMatch.Groups[2].Value, out float y) &&
+                        byte.TryParse(dungeonMatch.Groups[3].Value, out byte xSector))
+                    {
+                        object[] args = { Position.FromCoordinates(x, y, xSector) };
+                        return new ScriptCommand { Type = ScriptCommandType.Move, arguments = args };
+                    }
+                }
+                else
+                {
+                    var regex = new Regex(@"\D(-*\d+),(-*\d+)[\s\S]*");
+                    var match = regex.Match(cmdTrimmed);
+                    if (match.Success)
+                    {
+                        if (float.TryParse(match.Groups[1].Value, out float x) &&
+                            float.TryParse(match.Groups[2].Value, out float y))
+                        {
+                            byte? xSector = null;
+                            if (x <= -20000) xSector = 1; // dungeon coords but no x sector, assuming dw cave
+                            object[] args = { Position.FromCoordinates(x, y, xSector) };
+                            return new ScriptCommand { Type = ScriptCommandType.Move, arguments = args };
+                        }
+                    }
+                }
+            }
+            if (cmdTrimmed.StartsWith("teleport"))
+            {
+                var regex = new Regex(@"\D(-*\d+),(-*\d+)[\s\S]*");
+                var match = regex.Match(cmdTrimmed);
+                if (match.Success)
+                {
+                    if (uint.TryParse(match.Groups[1].Value, out uint npcId) &&
+                        uint.TryParse(match.Groups[2].Value, out uint destination))
+                    {
+                        object[] args = { npcId, destination };
+                        return new ScriptCommand { Type = ScriptCommandType.TeleportById, arguments = args };
+                    }
+                }
+            }
+            if (cmdTrimmed.StartsWith("wait"))
+            {
+                object[] args = { 5000 };
+                return new ScriptCommand { Type = ScriptCommandType.Wait, arguments = args };
+            }
+
+            Log.Notify($"Unknown / invalid script command [{command}]");
+            return new ScriptCommand { Type = ScriptCommandType.Unknown };
+        }
+    }
+}

--- a/Library/RSBot.Core/Components/NativeScriptParser.cs
+++ b/Library/RSBot.Core/Components/NativeScriptParser.cs
@@ -1,0 +1,119 @@
+﻿using RSBot.Core.Objects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Components
+{
+    public class NativeScriptParser : IScriptParser
+    {
+        public ScriptCommand[] ParseCommands(string[] commands)
+        {
+            List<ScriptCommand> result = new List<ScriptCommand>();
+            foreach (var command in commands)
+            {
+                result.Add(ParseCommand(command));
+            }
+            return result.ToArray();
+        }
+
+        private ScriptCommand ParseCommand(string command)
+        {
+            if (string.IsNullOrWhiteSpace(command))
+            {
+                return new ScriptCommand { Type = ScriptCommandType.Unknown };
+            }
+
+            var cmdTrimmed = command.Trim();
+
+            var arguments = cmdTrimmed.Split(' ');
+
+            switch (arguments[0].ToLower())
+            {
+                case "move":
+                    try
+                    {
+                        var pos = new Position
+                        {
+                            XSector = byte.Parse(arguments[4]),
+                            YSector = byte.Parse(arguments[5]),
+                            XOffset = float.Parse(arguments[1]),
+                            YOffset = float.Parse(arguments[2]),
+                            ZOffset = float.Parse(arguments[3])
+                        };
+                        object[] args = { pos };
+                        return new ScriptCommand { Type = ScriptCommandType.Move, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "teleport":
+                    try
+                    {
+                        object[] args = { arguments[1], arguments[2] };
+                        return new ScriptCommand { Type = ScriptCommandType.TeleportByCode, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "wait":
+                    try
+                    {
+                        object[] args = { int.Parse(arguments[1]) };
+                        return new ScriptCommand { Type = ScriptCommandType.Wait, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "buy":
+                    try
+                    {
+                        object[] args = { arguments[1] };
+                        return new ScriptCommand { Type = ScriptCommandType.Buy, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "repair":
+                    try
+                    {
+                        object[] args = { arguments[1] };
+                        return new ScriptCommand { Type = ScriptCommandType.Repair, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "store":
+                    try
+                    {
+                        object[] args = { arguments[1] };
+                        return new ScriptCommand { Type = ScriptCommandType.Store, arguments = args };
+                    }
+                    catch
+                    {
+                        Log.Notify($"Invalid script command [{command}]");
+                        return new ScriptCommand { Type = ScriptCommandType.Unknown };
+                    }
+                case "dismount":
+                    return new ScriptCommand { Type = ScriptCommandType.Dismount };
+                default:
+                    Log.Notify($"Unknown script command [{arguments[0]}]");
+                    return new ScriptCommand { Type = ScriptCommandType.Unknown };
+            }
+
+            
+        }
+    }
+}

--- a/Library/RSBot.Core/Components/ScriptManager.cs
+++ b/Library/RSBot.Core/Components/ScriptManager.cs
@@ -81,7 +81,7 @@ namespace RSBot.Core.Components
         /// <summary>
         /// Runs this instance.
         /// </summary>
-        public static void RunScript()
+        public static void RunScript(bool castBuffs = false)
         {
             if (Commands == null || Commands.Length == 0)
             {
@@ -90,9 +90,20 @@ namespace RSBot.Core.Components
             }
 
             Running = true;
+            var useSpeedDrug = PlayerConfig.Get<bool>("RSBot.Walkback.UseSpeedDrug", false);
+            var canBuff = true;
+
             foreach (var command in Commands)
             {
                 if (!Running) return;
+                if (canBuff)
+                {
+                    if (useSpeedDrug && Game.Player.State.ActiveBuffs.FindIndex(p => p.Record.Action_Overlap == 6) < 0)
+                        Game.Player.UseSpeedDrug();
+                    if (castBuffs)
+                        SkillManager.CastBuffs();
+                }
+                else canBuff = true;
 
                 switch (command.Type)
                 {
@@ -120,6 +131,7 @@ namespace RSBot.Core.Components
                     case ScriptCommandType.TeleportByCode:
                     case ScriptCommandType.TeleportById:
                         Log.Notify("[Script] Teleporting...");
+                        canBuff = false;
                         ExecuteTeleport(command);
                         break;
 

--- a/Library/RSBot.Core/Components/SkillManager.cs
+++ b/Library/RSBot.Core/Components/SkillManager.cs
@@ -534,5 +534,27 @@ namespace RSBot.Core.Components
 
             return callback.IsCompleted;
         }
+
+        public static bool CastBuffs()
+        {
+            if (Game.Player.State.LifeState != LifeState.Alive)
+                return false;
+
+            var buffs = Buffs.FindAll(p => !Game.Player.State.HasActiveBuff(p, out _) && p.CanBeCasted);
+
+            foreach (var buff in buffs)
+            {
+                if (Game.Player.State.LifeState != LifeState.Alive)
+                    return false;
+                var playerSkill = Game.Player.Skills.GetSkillInfoById(buff.Id);
+                if (playerSkill == null)
+                    continue;
+
+                Log.Debug($"Trying to cast buff: {buff} {buff.Record.Basic_Code}");
+                CastBuff(buff);
+            }
+
+            return true;
+        }
     }
 }

--- a/Library/RSBot.Core/Objects/Player.cs
+++ b/Library/RSBot.Core/Objects/Player.cs
@@ -569,7 +569,7 @@ namespace RSBot.Core.Objects
         public bool MoveTo(Position destination, bool sleep = true)
         {
             var distance = Game.Player.Movement.Source.DistanceTo(destination);
-            if (distance > 150)
+            if (distance > 300)
             {
                 Log.Warn($"Player.Move: Target position too far away! Target distance: {Math.Round(distance, 2)}");
 
@@ -616,7 +616,7 @@ namespace RSBot.Core.Objects
                 if (!sleep) return true;
 
                 //Wait to finish the step
-                Thread.Sleep(Convert.ToInt32(distance / Game.Player.ActualSpeed * 10000));
+                Thread.Sleep(Convert.ToInt32(distance / Game.Player.ActualSpeed * 10000 + 100));
 
                 return true;
             }
@@ -651,6 +651,7 @@ namespace RSBot.Core.Objects
                     {
                         duration = 4050;
                     }
+                    //duration = 500;
                 }
                 var elapsed = Environment.TickCount - tick;
                 Log.Debug($"{potionItem.Record.GetRealName()} {tick}   {elapsed} {duration}    {elapsed < duration}");

--- a/Library/RSBot.Core/Objects/Player.cs
+++ b/Library/RSBot.Core/Objects/Player.cs
@@ -651,7 +651,6 @@ namespace RSBot.Core.Objects
                     {
                         duration = 4050;
                     }
-                    //duration = 500;
                 }
                 var elapsed = Environment.TickCount - tick;
                 Log.Debug($"{potionItem.Record.GetRealName()} {tick}   {elapsed} {duration}    {elapsed < duration}");
@@ -738,6 +737,22 @@ namespace RSBot.Core.Objects
                 _lastPurificationPillTick = Environment.TickCount;
 
             return result;
+        }
+
+        /// <summary>
+        /// Uses the speed drug.
+        /// </summary>
+        /// <returns></returns>
+        public bool UseSpeedDrug()
+        {
+            if (State.LifeState == LifeState.Dead)
+                return false;
+
+            var item = Game.Player.Inventory.GetItems(new TypeIdFilter(3, 3, 13, 1)).Find(p => p.Record.Desc1.Contains("_SPEED_"));
+            if (item != null)
+                return item.Use();
+
+            return false;
         }
 
         /// <summary>

--- a/Library/RSBot.Core/Objects/Position.cs
+++ b/Library/RSBot.Core/Objects/Position.cs
@@ -159,6 +159,33 @@ namespace RSBot.Core.Objects
         }
 
         /// <summary>
+        /// Reads X and Y coordinates and returns a new Postion object.
+        /// </summary>
+        /// <param name="packet">The packet.</param>
+        /// <returns></returns>
+        public static Position FromCoordinates(float x, float y, byte? xSector = null)
+        {
+            if (xSector != null)
+            {
+                return new Position
+                {
+                    YSector = 128,
+                    XSector = (byte)xSector,
+                    XCoordinate = x,
+                    YCoordinate = y,
+                };
+            }
+            else
+            {
+                return new Position
+                {
+                    XCoordinate = x,
+                    YCoordinate = y,
+                };
+            }
+        }
+
+        /// <summary>
         /// Calculates the distance to the destination
         /// </summary>
         /// <param name="position">The position.</param>

--- a/Library/RSBot.Core/Objects/ScriptCommand.cs
+++ b/Library/RSBot.Core/Objects/ScriptCommand.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Objects
+{
+    public class ScriptCommand
+    {
+        public ScriptCommandType Type { get; set; }
+        public object[] arguments { get; set; }
+    }
+}

--- a/Library/RSBot.Core/Objects/ScriptCommandType.cs
+++ b/Library/RSBot.Core/Objects/ScriptCommandType.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Objects
+{
+    public enum ScriptCommandType
+    {
+        Move,
+        Buy,
+        Repair,
+        Store,
+        TeleportByCode,
+        TeleportById,
+        Dismount,
+        Wait,
+        Unknown
+    }
+}

--- a/Library/RSBot.Core/Objects/Skill/SkillInfo.cs
+++ b/Library/RSBot.Core/Objects/Skill/SkillInfo.cs
@@ -83,8 +83,7 @@ namespace RSBot.Core.Objects.Skill
         /// <value>
         /// <c>true</c> if this instance can be used; otherwise, <c>false</c>.
         /// </value>
-        public bool CanNotBeCasted
-            => (Environment.TickCount - _canNotBeCastedTick) < _duration;
+        public bool CanNotBeCasted => !CanBeCasted;
 
         /// <summary>
         /// Gets a value indicating whether this instance can be used.
@@ -92,7 +91,7 @@ namespace RSBot.Core.Objects.Skill
         /// <value>
         /// <c>true</c> if this instance can be used; otherwise, <c>false</c>.
         /// </value>
-        public bool CanBeCasted => (IsDot || !CanNotBeCasted) && !HasCooldown && Game.Player.Mana >= Record.Consume_MP;
+        public bool CanBeCasted => !HasCooldown && Game.Player.Mana >= Record.Consume_MP;
 
         /// <summary>
         /// Skill Token (using for buffs)

--- a/Library/RSBot.Core/RSBot.Core.csproj
+++ b/Library/RSBot.Core/RSBot.Core.csproj
@@ -60,6 +60,9 @@
     <Compile Include="Client\ReferenceObjects\RefPackageItemScrap.cs" />
     <Compile Include="Client\ReferenceObjects\RefText.cs" />
     <Compile Include="Client\ReferenceParser.cs" />
+    <Compile Include="Components\IScriptParser.cs" />
+    <Compile Include="Components\MbotScriptParser.cs" />
+    <Compile Include="Components\NativeScriptParser.cs" />
     <Compile Include="Components\Pk2\ArchiveFile.cs" />
     <Compile Include="Components\Pk2\ArchiveManager.cs" />
     <Compile Include="Components\CollisionManager.cs" />
@@ -170,6 +173,8 @@
     <Compile Include="Objects\BadEffect.cs" />
     <Compile Include="Objects\BattleState.cs" />
     <Compile Include="Objects\InventoryItemState.cs" />
+    <Compile Include="Objects\ScriptCommand.cs" />
+    <Compile Include="Objects\ScriptCommandType.cs" />
     <Compile Include="Objects\ScrollState.cs" />
     <Compile Include="Objects\Spawn\SpawnedEntity.cs" />
     <Compile Include="Objects\Spawn\SpawnedNpcNpc.cs" />


### PR DESCRIPTION
- Mbot scripts can now be used for walkback (native RSBot scripts are of course still working as previously)
- Speed drugs will now be used during townscript (if enabled)
- Speed drugs and buffs will be recasted in between script steps if they expire during the walkback (if enabled)
- Fixed an issue where buffs would not be recasted if they ended quicker than their duration (for example after teleports)