### PR TITLE
[Feature] Add check for ammunition and potions when the bot starts

### DIFF
--- a/Plugins/RSBot.Protection/Components/Town/AmmunitionHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Town/AmmunitionHandler.cs
@@ -19,6 +19,12 @@ namespace RSBot.Protection.Components.Town
         private static void SubscribeEvents()
         {
             EventManager.SubscribeEvent("OnUpdateAmmunition", OnUpdateAmmunition);
+            EventManager.SubscribeEvent("OnStartBot", OnStartBot);
+        }
+
+        private static void OnStartBot()
+        {
+            CheckForAmmunition();
         }
 
         /// <summary>
@@ -26,14 +32,16 @@ namespace RSBot.Protection.Components.Town
         /// </summary>
         private static void OnUpdateAmmunition()
         {
-            if (!Kernel.Bot.Running)
-                return;
+            if (Kernel.Bot.Running) CheckForAmmunition();
+        }
 
+        private static void CheckForAmmunition()
+        {
             if (!PlayerConfig.Get<bool>("RSBot.Protection.checkNoArrows"))
                 return;
 
-            var currentAmmuniton = Game.Player.GetAmmunationAmount(true);
-            if (currentAmmuniton == -1 || currentAmmuniton > 10) 
+            var currentAmmunition = Game.Player.GetAmmunationAmount(true);
+            if (currentAmmunition == -1 || currentAmmunition > 10)
                 return;
 
             Log.WarnLang("ReturnToTownNoAmmo");

--- a/Plugins/RSBot.Protection/Components/Town/LevelUpHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Town/LevelUpHandler.cs
@@ -1,6 +1,5 @@
 ﻿using RSBot.Core;
 using RSBot.Core.Event;
-using RSBot.Protection.Views;
 
 namespace RSBot.Protection.Components.Town
 {
@@ -37,7 +36,5 @@ namespace RSBot.Protection.Components.Town
 
             Game.Player.UseReturnScroll();
         }
-
-        
     }
 }

--- a/Plugins/RSBot.Protection/Components/Town/NoHealthPotionsHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Town/NoHealthPotionsHandler.cs
@@ -21,6 +21,13 @@ namespace RSBot.Protection.Components.Town
         private static void SubscribeEvents()
         {
             EventManager.SubscribeEvent("OnUseItem", new System.Action<byte>(OnUseItem));
+            EventManager.SubscribeEvent("OnStartBot", OnStartBot);
+        }
+
+        private static void OnStartBot()
+        {
+            //Check if we need to return to town right after the bot started.
+            CheckForHpPotions();
         }
 
         /// <summary>
@@ -28,7 +35,11 @@ namespace RSBot.Protection.Components.Town
         /// </summary>
         private static void OnUseItem(byte slot)
         {
-            if (!Kernel.Bot.Running) return;
+            if (Kernel.Bot.Running) CheckForHpPotions();
+        }
+
+        private static void CheckForHpPotions()
+        {
             if (!PlayerConfig.Get<bool>("RSBot.Protection.checkNoHPPotions")) return;
 
             var typeIdFilter = new TypeIdFilter(3, 3, 1, 1);

--- a/Plugins/RSBot.Protection/Components/Town/NoManaPotionsHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Town/NoManaPotionsHandler.cs
@@ -21,6 +21,13 @@ namespace RSBot.Protection.Components.Town
         private static void SubscribeEvents()
         {
             EventManager.SubscribeEvent("OnUseItem", new System.Action<byte>(OnUseItem));
+            EventManager.SubscribeEvent("OnStartBot", OnStartBot);
+        }
+
+        private static void OnStartBot()
+        {
+            //Check if we need to return to town right after the bot started.
+            CheckForMpPotions();
         }
 
         /// <summary>
@@ -28,7 +35,12 @@ namespace RSBot.Protection.Components.Town
         /// </summary>
         private static void OnUseItem(byte slot)
         {
-            if (!Kernel.Bot.Running) return;
+            if (Kernel.Bot.Running) CheckForMpPotions();
+ 
+        }
+
+        private static void CheckForMpPotions()
+        {
             if (!PlayerConfig.Get<bool>("RSBot.Protection.checkNoMPPotions")) return;
 
             var typeIdFilter = new TypeIdFilter(3, 3, 1, 2);


### PR DESCRIPTION
[Feature/Bugfix]
* Add check for ammuntion and HP/MP potions when starting the bot, otherwise they will never be called if there were no items in the inventory in the first place 