### PR TITLE
Fixed COSTUME_ETC being treated as job outfits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,4 +363,7 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 
+# JetBrains Rider
+.idea/
+
 !RSBot.Log

--- a/Library/RSBot.Core/Client/ReferenceObjects/RefObjItem.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/RefObjItem.cs
@@ -107,7 +107,7 @@
         /// <summary>
         /// A value indicating if the item is of type wearable for job
         /// </summary>
-        public bool IsJobOutfit => IsEquip && TypeID3 == 7;
+        public bool IsJobOutfit => IsEquip && TypeID3 == 7 && TypeID4 != 4 && TypeID4 != 5;
 
         /// <summary>
         /// A value indicating if the item is of type stackable


### PR DESCRIPTION
Costumes from group WK_COSTUME was being treated as job outfits, this caused spawn packet to be parsed incorrectly.