### PR TITLE
Fixed training not working if collision files are missing

### DIFF
--- a/Library/RSBot.Core/Components/Collision/CollisionLoader.cs
+++ b/Library/RSBot.Core/Components/Collision/CollisionLoader.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace RSBot.Core.Components.Collision
 {
-    internal class CollisionLoader
+    internal class CollisionLoader : ICollisionLoader
     {
         /// <summary>
         /// The collisions

--- a/Library/RSBot.Core/Components/Collision/ICollisionLoader.cs
+++ b/Library/RSBot.Core/Components/Collision/ICollisionLoader.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace RSBot.Core.Components.Collision;
+
+internal interface ICollisionLoader
+{
+    List<Line> GetCollisions(int regionId);
+}

--- a/Library/RSBot.Core/Components/Collision/NoCollisionLoader.cs
+++ b/Library/RSBot.Core/Components/Collision/NoCollisionLoader.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace RSBot.Core.Components.Collision;
+
+/// <summary>
+/// Default collision loader.
+/// Used when no other loader is available. 
+/// </summary>
+internal class NoCollisionLoader : ICollisionLoader
+{
+    public List<Line> GetCollisions(int regionId)
+    {
+        return new List<Line>();
+    }
+}

--- a/Library/RSBot.Core/Components/CollisionManager.cs
+++ b/Library/RSBot.Core/Components/CollisionManager.cs
@@ -26,7 +26,7 @@ namespace RSBot.Core.Components
         /// </value>
         public static Objects.Region Region { get; private set; }
 
-        private static CollisionLoader _collisionLoader;
+        private static ICollisionLoader _collisionLoader = new NoCollisionLoader();
 
         private static List<Line> _collisions;
 
@@ -40,7 +40,7 @@ namespace RSBot.Core.Components
 
             if (!File.Exists(collisionFile) || !File.Exists(collisionIndexFile))
             {
-                Log.Error("Could not find collision files, collision detection will not be functional.");
+                Log.Warn("Could not find collision files, collision detection will not be functional.");
                 return;
             }
 
@@ -53,9 +53,6 @@ namespace RSBot.Core.Components
         /// <param name="regionId">The region identifier.</param>
         internal static void Update(ushort regionId)
         {
-            if (_collisionLoader == null)
-                return;
-
             var stopWatch = new Stopwatch();
             stopWatch.Start();
 


### PR DESCRIPTION
If for some reason collision files are not found bot doesn't even attempt to start training, the message suggests otherwise.
I think it's logical to keep training working even if it's degraded.
