### PR TITLE
Seperated pet pickup from player pickup

### DIFF
--- a/Botbases/RSBot.Default/Bot/Botbase.cs
+++ b/Botbases/RSBot.Default/Bot/Botbase.cs
@@ -51,7 +51,7 @@ namespace RSBot.Default.Bot
             }
 
             //Wait for the pickup manager to finish
-            if (PickupManager.Running && !(Bundles.Loot.Config.UseAbilityPet && Game.Player.HasActiveAbilityPet))
+            if (PickupManager.RunningPlayerPickup && !(Bundles.Loot.Config.UseAbilityPet && Game.Player.HasActiveAbilityPet))
                 return;
 
             if (Bundles.Loop.Config.UseSpeedDrug && Game.Player.State.ActiveBuffs.FindIndex(p => p.Record.Params.Contains(1752396901)) < 0)

--- a/Botbases/RSBot.Default/Bot/Botbase.cs
+++ b/Botbases/RSBot.Default/Bot/Botbase.cs
@@ -51,7 +51,7 @@ namespace RSBot.Default.Bot
             }
 
             //Wait for the pickup manager to finish
-            if (PickupManager.RunningPlayerPickup && !(Bundles.Loot.Config.UseAbilityPet && Game.Player.HasActiveAbilityPet))
+            if (PickupManager.RunningPlayerPickup)
                 return;
 
             if (Bundles.Loop.Config.UseSpeedDrug && Game.Player.State.ActiveBuffs.FindIndex(p => p.Record.Params.Contains(1752396901)) < 0)

--- a/Botbases/RSBot.Default/Bundle/Loot/Lootbundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Loot/Lootbundle.cs
@@ -27,18 +27,16 @@ namespace RSBot.Default.Bundle.Loot
 
             //If we use the ability pet, we can attack during the work of the Pickup manager
             if (Config.UseAbilityPet && Game.Player.HasActiveAbilityPet)
-                Task.Run(() => PickupManager.Run(Container.Bot.Area.CenterPosition, Container.Bot.Area.Radius));
-            else
-            {
-                if (Bundles.Loot.Config.DontPickupInBerzerk && Game.Player.Berzerking || ScriptManager.Running)
-                    return;
+                Task.Run(() => PickupManager.RunAbilityPet( Container.Bot.Area.CenterPosition, Container.Bot.Area.Radius));
 
-                //Don't pickup if a mob is selected
-                if (Game.SelectedEntity is SpawnedMonster monster && monster.State.LifeState == LifeState.Alive)
-                    return;
+            if (Bundles.Loot.Config.DontPickupInBerzerk && Game.Player.Berzerking || ScriptManager.Running)
+                return;
 
-                PickupManager.Run(Container.Bot.Area.CenterPosition, Container.Bot.Area.Radius);
-            }
+            //Don't pickup if a mob is selected
+            if (Game.SelectedEntity is SpawnedMonster monster && monster.State.LifeState == LifeState.Alive)
+                return;
+
+            PickupManager.RunPlayer( Game.Player.Movement.Source, Container.Bot.Area.CenterPosition, Container.Bot.Area.Radius);
         }
 
         /// <summary>
@@ -56,8 +54,11 @@ namespace RSBot.Default.Bundle.Loot
 
         public void Stop()
         {
-            if (PickupManager.Running)
-                PickupManager.Stop();
+            if (PickupManager.RunningPlayerPickup)
+                PickupManager.StopPlayerPickup();
+
+            if( PickupManager.RunningAbilityPetPickup )
+                PickupManager.StopAbilityPetPickup();
         }
     }
 }

--- a/Library/RSBot.Core/Bot.cs
+++ b/Library/RSBot.Core/Bot.cs
@@ -87,7 +87,8 @@ namespace RSBot.Core
             Game.SelectedEntity = null;
             ScriptManager.Stop();
             ShoppingManager.Stop();
-            PickupManager.Stop();
+            PickupManager.StopPlayerPickup();
+            PickupManager.StopAbilityPetPickup();
             Botbase.Stop();
 
             Running = false;

--- a/Library/RSBot.Core/Components/PickupManager.cs
+++ b/Library/RSBot.Core/Components/PickupManager.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace RSBot.Core.Components
 {
-    public class PickupManager
+    public class PickupManager 
     {
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="PickupManager"/> is running.
@@ -15,7 +15,15 @@ namespace RSBot.Core.Components
         /// <value>
         ///   <c>true</c> if running; otherwise, <c>false</c>.
         /// </value>
-        public static bool Running { get; private set; }
+        public static bool RunningPlayerPickup { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="PickupManager"/> is running for AbilityPet.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if running; otherwise, <c>false</c>.
+        /// </value>
+        public static bool RunningAbilityPetPickup { get; private set; }
 
         /// <summary>
         /// Gets or sets the pickup items.
@@ -68,84 +76,34 @@ namespace RSBot.Core.Components
         /// <summary>
         /// Runs the specified center position.
         /// </summary>
+        /// <param name="playerPosition">The player position.</param>
         /// <param name="centerPosition">The center position.</param>
         /// <param name="radius">The radius.</param>
-        public static void Run(Position centerPosition, int radius = 50)
+        public static void RunPlayer(Position playerPosition, Position centerPosition, int radius = 50)
         {
             // if the manager is busy,return
-            if (Running)
+            if ( RunningPlayerPickup )
                 return;
 
-            Running = true;
-            try
+            RunningPlayerPickup = true;
+            try 
             {
-                var playerJid = Game.Player.JID;
-
-                bool condition(SpawnedItem e)
+                if (!SpawnManager.TryGetEntities<SpawnedItem>( out var entities, (si) => Condition( si, centerPosition, radius )
+                    && ( !UseAbilityPet || !Game.Player.HasActiveAbilityPet || PickupFilter.Any( p => p.CodeName == si.Record.CodeName && p.PickOnlyChar ) ) ) )
                 {
-                    if (JustPickMyItems && e.OwnerJID != playerJid)
-                        return false;
-
-                    //Don't pickup items that still belong to another player
-                    if (e.HasOwner && e.OwnerJID != playerJid)
-                        return false;
-
-                    const int tolerance = 15;
-                    var isInside = e.Movement.Source.DistanceTo(centerPosition) <= radius + tolerance;
-                    if (!isInside)
-                        return false;
-
-                    if (PickupGold && e.Record.IsGold)
-                        return true;
-
-                    if (PickupFilter.Any(p => p.CodeName == e.Record.CodeName))
-                        return true;
-
-                    if (PickupRareItems && (byte)e.Rarity >= 2)
-                        return true;
-
-                    if (PickupBlueItems && (byte)e.Rarity >= 1)
-                        return true;
-
-                    return false;
-                }
-
-                if (!SpawnManager.TryGetEntities<SpawnedItem>(out var entities, condition))
-                {
-                    Stop();
+                    StopPlayerPickup();
                     return;
                 }
 
-                if (UseAbilityPet && Game.Player.HasActiveAbilityPet)
+                EventManager.FireEvent( "OnChangeStatusText", "Picking up" );
+                foreach( var item in entities.OrderBy( item => item.Movement.Source.DistanceTo( playerPosition )/*.Take(5)*/) )
                 {
-                    foreach (var item in entities.OrderBy(item => item.Movement.Source.DistanceTo(centerPosition))/*.Take(5)*/)
-                    {
-                        if (!Running)
-                            return;
+                    if( !RunningPlayerPickup )
+                        return;
 
-                        if (PickupFilter.Any(p => p.CodeName == item.Record.CodeName && p.PickOnlyChar))
-                        {
-                            Game.Player.MoveTo(item.Movement.Source);
-
-                            item.Pickup();
-                        }
-                        else
-                            Game.Player.AbilityPet.Pickup(item.UniqueId);
-                    }
-                }
-                else
-                {
-                    var itemsToPickup = entities.OrderBy(item => item.Movement.Source.DistanceTo(centerPosition));
-
-                    EventManager.FireEvent("OnChangeStatusText", "Picking up");
-
-                    foreach (var item in itemsToPickup)
-                    {
-                        //Make sure the player is at the item's location
-                        //Game.Player.MoveTo(item.Movement.Source);
-
-                        item.Pickup();
-                    }
+                    //Make sure the player is at the item's location
+                    //Game.Player.MoveTo(item.Movement.Source);
+                    item.Pickup();
                 }
             }
             catch (Exception e)
@@ -154,8 +112,70 @@ namespace RSBot.Core.Components
             }
             finally
             {
-                Stop();
+                StopPlayerPickup();
             }
+        }
+
+        public static void RunAbilityPet( Position centerPosition, int radius = 50 ) 
+        {
+            if( RunningAbilityPetPickup || !UseAbilityPet || !Game.Player.HasActiveAbilityPet )
+                return;
+
+            RunningAbilityPetPickup = true;
+            try {
+                if( !SpawnManager.TryGetEntities<SpawnedItem>( out var entities, ( si ) => Condition( si, centerPosition, radius ) 
+                    && PickupFilter.Any( p => p.CodeName == si.Record.CodeName && !p.PickOnlyChar ) ) ) 
+                {
+                    StopAbilityPetPickup();
+                    return;
+                }
+
+                foreach( var item in entities.OrderBy( item => item.Movement.Source.DistanceTo( centerPosition )/*.Take(5)*/) ) {
+                    if( !RunningAbilityPetPickup )
+                        return;
+
+                    Game.Player.AbilityPet.Pickup( item.UniqueId );
+                }
+            }
+            catch ( Exception e )
+            {
+                Log.Fatal( e );
+            }
+            finally 
+            {
+                StopAbilityPetPickup();
+            }
+        }
+
+        private static bool Condition( SpawnedItem e, Position centerPosition, int radius ) {
+            var playerJid = Game.Player.JID;
+
+            if( JustPickMyItems && e.OwnerJID != playerJid )
+                return false;
+
+            // Don't pickup items that still belong to another player
+            if( e.HasOwner && e.OwnerJID != playerJid )
+                return false;
+
+            // Check if Item is within the training area + tolerance
+            const int tolerance = 15;
+            var isInside = e.Movement.Source.DistanceTo( centerPosition ) <= radius + tolerance;
+            if( !isInside )
+                return false;
+
+            if( PickupGold && e.Record.IsGold )
+                return true;
+
+            if( PickupFilter.Any( p => p.CodeName == e.Record.CodeName ) )
+                return true;
+
+            if( PickupRareItems && ( byte )e.Rarity >= 2 )
+                return true;
+
+            if( PickupBlueItems && ( byte )e.Rarity >= 1 )
+                return true;
+
+            return false;
         }
 
         public static void AddFilter(string codeName, bool pickOnlyChar = false)
@@ -198,9 +218,16 @@ namespace RSBot.Core.Components
         /// <summary>
         /// Stops this instance.
         /// </summary>
-        public static void Stop()
+        public static void StopPlayerPickup()
         {
-            Running = false;
+            RunningPlayerPickup = false;
+        }
+
+        /// <summary>
+        /// Stops this instance AbilityPet.
+        /// </summary>
+        public static void StopAbilityPetPickup() {
+            RunningAbilityPetPickup = false;
         }
     }
 }


### PR DESCRIPTION
When the ability pet was used there were some conditions bypassed for the pickup by player and other overlappings with the asynchronous commands.

The LootBundle checks if the ability pet is used and starts the pickup in another task before checking for bezerk or mob selection.
Subsequently the PickupManager checks for items that are marked as "pickup only by player" and starts the pickup command immediately.
In the same tick the attack command is called because there is still a monster selection active.

I fixed that by simply seperated both pickups. The pet can pickup async but the player always follows it's rules to only pickup when no monster attacking and no bezerk (if set)