### PR TITLE
fixed - GetRandomPosition overrides center position

### DIFF
--- a/Botbases/RSBot.Default/Bot/Objects/TrainingArea.cs
+++ b/Botbases/RSBot.Default/Bot/Objects/TrainingArea.cs
@@ -76,7 +76,7 @@ namespace RSBot.Default.Bot.Objects
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Position GetRandomPosition()
         {
-            var destination = Position;
+            var destination = new Position( Position.X, Position.Y, Position.RegionId );
 
             var angle = MathF.SinCos(2.0f * MathF.PI * _random.NextFloat());
 


### PR DESCRIPTION
Random walking overrides the original center-position. 
Fixed it by instancing a new Position.