### PR TITLE
Fixes2/skill scale down selection

### DIFF
--- a/Library/RSBot.Core/Components/SkillManager.cs
+++ b/Library/RSBot.Core/Components/SkillManager.cs
@@ -120,7 +120,7 @@ namespace RSBot.Core.Components
             {
                 for( var i = monster.Rarity; i > MonsterRarity.General; i-- ) 
                 {
-                    if( Skills[ i ].Count > 0 ) 
+                    if( Skills.TryGetValue( i, out var s ) && s.Count > 0 ) 
                     {
                         rarity = i;
                         break;


### PR DESCRIPTION
Scale down skill selection.
Target a PT Giant but only PT is configured, then rather use PT than General skills.
And cleaned up the code a bit.