### PR TITLE
Add retry logic for move commands

### DIFF
--- a/Botbases/RSBot.Default/Bundle/Loop/LoopBundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Loop/LoopBundle.cs
@@ -96,7 +96,8 @@ namespace RSBot.Default.Bundle.Loop
         /// </summary>
         public void CheckForTownScript()
         {
-            if (ScriptManager.Running) return;
+            if (ScriptManager.Running) 
+                return;
 
             var filename = Path.Combine(ScriptManager.InitialDirectory, "Towns", Game.Player.Movement.Source.RegionId + ".rbs");
 
@@ -142,13 +143,13 @@ namespace RSBot.Default.Bundle.Loop
 
             Invoke();
 
-            CheckForWalkbackScript();
+            CheckForWalkbackScript(true);
         }
 
         /// <summary>
         /// Checks for walkback script.
         /// </summary>
-        public void CheckForWalkbackScript()
+        public void CheckForWalkbackScript(bool startFromTown = false)
         {
             if (Config.WalkScript == null ||
                 ScriptManager.Running ||
@@ -160,7 +161,7 @@ namespace RSBot.Default.Bundle.Loop
             Log.NotifyLang("LoadingWalkScript", Config.WalkScript);
             
             ScriptManager.Load(Config.WalkScript);
-            ScriptManager.RunScript();
+            ScriptManager.RunScript(!startFromTown);
         }
     }
 }

--- a/Library/RSBot.Core/Components/ScriptManager.cs
+++ b/Library/RSBot.Core/Components/ScriptManager.cs
@@ -130,11 +130,12 @@ namespace RSBot.Core.Components
             if (CurrentLineIndex != 0)
                 Log.Debug($"[Script] Found nearby walk position at line #{CurrentLineIndex}");
 
-            foreach (var scriptLine in Commands.Skip(CurrentLineIndex/* + 1*/))
+            foreach (var scriptLine in Commands.Skip(CurrentLineIndex))
             {
-                EventManager.FireEvent("OnChangeStatusText", "Running walk script");
+                if (!Running)
+                    break;
 
-                if (!Running) return;
+                EventManager.FireEvent("OnChangeStatusText", "Running walk script");
 
                 var arguments = scriptLine.Split(' ');
                 var commandName = arguments.Length == 0 ? scriptLine : arguments[0];

--- a/Library/RSBot.Core/Components/Scripting/Commands/MoveScriptCommand.cs
+++ b/Library/RSBot.Core/Components/Scripting/Commands/MoveScriptCommand.cs
@@ -1,6 +1,6 @@
 ﻿using RSBot.Core.Objects;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace RSBot.Core.Components.Scripting.Commands
 {
@@ -64,21 +64,26 @@ namespace RSBot.Core.Components.Scripting.Commands
                 IsRunning = true;
 
                 while (Game.Player.InAction)
-                    Task.Delay(50);
+                    Thread.Sleep(50);
 
                 const int retryAttempts = 5;
                 var stepRetryCounter = 0;
 
                 //In some cases the move command fails for no reason, that's why we retry the move x times if it fails.
-                //This bug is server side. Sometimes it simply sends back a failed packet.
+                //This bug is server side. Sometimes it simply sends back a failed packet because the player state doesn't allow to move.
                 while (!ExecuteMove(arguments))
                 {
                     if (stepRetryCounter++ >= retryAttempts)
+                    {
+                        Log.Warn("[Script] The move command failed due to an unknown reason! Please check the walk script.");
+                        
                         return false;
+                    }
 
                     Log.Debug($"[Script] Retry this step {stepRetryCounter}/{retryAttempts}...");
 
-                    Task.Delay(1000);
+                    //Wait until executing the next step so the server can get its shit done so most likely the next step will not fail.
+                    Thread.Sleep(1000);
                 }
 
                 return true;


### PR DESCRIPTION
* If a move command failes (most likely due to server sync issues) it will be retried a maximum of 5 times.
* Walk scripts now always use the first script line if it was started right after a town script