### PR TITLE
Add conditions for the player to be able to attack

### DIFF
--- a/Botbases/RSBot.Default/Bundle/Attack/AttackBundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Attack/AttackBundle.cs
@@ -11,7 +11,7 @@ namespace RSBot.Default.Bundle.Attack
         /// </summary>
         public void Invoke()
         {
-            if (Game.SelectedEntity == null || Game.Player.HasActiveVehicle)
+            if (Game.SelectedEntity == null || !Game.Player.CanAttack)
                 return;
 
             if (Game.SelectedEntity.IsBehindObstacle)

--- a/Library/RSBot.Core/Objects/Player.cs
+++ b/Library/RSBot.Core/Objects/Player.cs
@@ -508,6 +508,53 @@ namespace RSBot.Core.Objects
         /// </value>
         public InventoryItem Weapon => Inventory.GetItemAt(6);
 
+
+        /// <summary>
+        /// Gets a value indicating whether this player is able to attack.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance can attack; otherwise, <c>false</c>.
+        /// </value>
+        public bool CanAttack
+        {
+            get
+            {
+                //State
+                if (State.LifeState == LifeState.Dead)
+                    return false;
+
+                if (State.ScrollState == ScrollState.NormalScroll)
+                    return false;
+
+                if (State.BodyState == BodyState.Untouchable)
+                    return false;
+
+                if (State.HitState == ActionHitStateFlag.KnockDown)
+                    return false;
+
+                if (HasActiveVehicle)
+                    return false;
+
+                if (State.MotionState == MotionState.Sitting)
+                    return false;
+
+                //Bad effects - probably there are more
+                if ((BadEffect & BadEffect.Fear) != 0)
+                    return false;
+
+                if ((BadEffect & BadEffect.Sleep) != 0)
+                    return false;
+
+                if ((BadEffect & BadEffect.Frozen) != 0)
+                    return false;
+
+                if ((BadEffect & BadEffect.Stunned) != 0)
+                    return false;
+
+                return true;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the last hp potion item tick count
         /// </summary>

--- a/Plugins/RSBot.Protection/Components/Pet/CosReviveHandler.cs
+++ b/Plugins/RSBot.Protection/Components/Pet/CosReviveHandler.cs
@@ -35,6 +35,9 @@ namespace RSBot.Protection.Components.Pet
                 return;
 
             var item = Game.Player.Inventory.GetItemAt(slot);
+            if (item == null)
+                return;
+
             var itemRecord = item.Record;
 
             if (!itemRecord.IsPet)


### PR DESCRIPTION
Fixed: The bot keeps spamming the spells eventhough it is technically unable to attack.