### PR TITLE
It wasn't read the party, chat etc etc strings because this client using unicode strings in packets

### DIFF
--- a/Library/RSBot.Core/Extensions/PacketExtensions.cs
+++ b/Library/RSBot.Core/Extensions/PacketExtensions.cs
@@ -17,6 +17,7 @@ namespace RSBot.Core.Extensions
                 case GameClientType.Global:
                 case GameClientType.Turkey:
                 case GameClientType.Korean:
+                case GameClientType.Rigid:
                     return packet.ReadUnicode();
                     
                 default:
@@ -37,6 +38,7 @@ namespace RSBot.Core.Extensions
                 case GameClientType.Global:
                 case GameClientType.Turkey:
                 case GameClientType.Korean:
+                case GameClientType.Rigid:
                     packet.WriteUnicode(str);
                     break;
 


### PR DESCRIPTION
It wasn't read the party, chat etc etc strings because this client using unicode strings in packets