### PR TITLE
Fix inventory sorting bug for the ammunition slot

### DIFF
--- a/Library/RSBot.Core/Objects/CharacterInventory.cs
+++ b/Library/RSBot.Core/Objects/CharacterInventory.cs
@@ -152,7 +152,7 @@ namespace RSBot.Core.Objects
             {
                 iterations++;
 
-                var itemsToStackGroups = this.Where(i => i.Record.IsStackable && i.Record.MaxStack > i.Amount && !blacklistedItems.Contains(i.ItemId))
+                var itemsToStackGroups = this.Where(i => i.Slot > 12 && i.Record.IsStackable && i.Record.MaxStack > i.Amount && !blacklistedItems.Contains(i.ItemId))
                     .GroupBy(i => i.ItemId);
 
                 if (!itemsToStackGroups.Any())


### PR DESCRIPTION
Fixes a bug where the bot tries to merge ammunition with freshly picked up ammunition resulting in buggy 5 seconds of switching slots around