### PR TITLE
Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Describe a bug you've encountered in RSBot
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Version (please complete the following information):**
+ - SRO version: [e.g. iSRO]
+ - RSBot version (or commit): [e.g. v2.3]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce the behavior:**
+Steps to reproduce the behavior:
+1. Walk to Samarkand
+2. Start bot
+3. Get disconnected from the server
+
+**(Optional) Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea or a feature for RSBot
+title: "[Feature request]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds two GitHub issue templates for issue types that are used quite frequently in this repo.

Preview is [here](https://github.com/dvdblk/RSBot/issues/new/choose).

This also allows anyone to use the correct GitHub issue labels properly as they are added automatically with the template. By default, labels can [only be added by contributors](https://stackoverflow.com/a/13829505/4249857).