### PR TITLE
Fix pet pickup packet awaiter blocking the attacking loop for 5 seconds

### DIFF
--- a/Library/RSBot.Core/Objects/CharacterInventory.cs
+++ b/Library/RSBot.Core/Objects/CharacterInventory.cs
@@ -135,7 +135,7 @@ namespace RSBot.Core.Objects
 
         public void Sort()
         {
-            if (IsSorting)
+            if (IsSorting || Game.Player.InAction)
                 return;
 
             IsSorting = true;

--- a/Library/RSBot.Core/Objects/Cos/Cos.cs
+++ b/Library/RSBot.Core/Objects/Cos/Cos.cs
@@ -181,20 +181,22 @@ namespace RSBot.Core.Objects.Cos
         {
             var packet = new Packet(0x70C5);
             packet.WriteUInt(UniqueId);
-            packet.WriteByte(0x08);
+            packet.WriteByte(CosCommand.Pickup);
             packet.WriteUInt(itemUniqueId);
 
             var callback = new AwaitCallback(response =>
             {
                 var result = response.ReadByte();
+
                 if (result == 0x01)
                 {
-                    response.ReadByte();
+                    response.ReadByte(); //command
+
                     return response.ReadUInt() == UniqueId ? AwaitCallbackResult.Success : AwaitCallbackResult.ConditionFailed;
                 }
 
                 return AwaitCallbackResult.Fail;
-            }, 0xB034);
+            }, 0xB0C5);
 
             PacketManager.SendPacket(packet, PacketDestination.Server, callback);
             callback.AwaitResponse();
@@ -209,7 +211,7 @@ namespace RSBot.Core.Objects.Cos
         {
             var packet = new Packet(0x70C5);
             packet.WriteUInt(UniqueId);
-            packet.WriteByte(1); //Move
+            packet.WriteByte(CosCommand.Move); //Move
             packet.WriteByte(1); //To point
             packet.WriteUShort(destination.RegionId);
 

--- a/Library/RSBot.Core/Objects/Cos/CosCommand.cs
+++ b/Library/RSBot.Core/Objects/Cos/CosCommand.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RSBot.Core.Objects.Cos;
+
+public enum CosCommand : byte
+{
+    Move = 1,
+    Attack = 2,
+    Pickup = 8,
+    Follow = 9,
+    Charm = 11,
+}

--- a/Library/RSBot.Core/Objects/Spawn/SpawnedEntity.cs
+++ b/Library/RSBot.Core/Objects/Spawn/SpawnedEntity.cs
@@ -97,10 +97,10 @@ namespace RSBot.Core.Objects.Spawn
                     _isBehindObstacle = CollisionManager.HasCollisionBetween(Game.Player.Position, Position);
 
                 //It's enough to check for collision every 1 second
-                if (DateTime.Now.Ticks - _lastCollisionTick >= 100000)
+                if (Kernel.TickCount - _lastCollisionTick >= TimeSpan.TicksPerSecond)
                     _isBehindObstacle = CollisionManager.HasCollisionBetween(Game.Player.Position, Position);
 
-                _lastCollisionTick = DateTime.Now.Ticks;
+                _lastCollisionTick = Kernel.TickCount;
 
                 return _isBehindObstacle;
             }


### PR DESCRIPTION
Fixed a bug where the pickup pet blocks the attack loop because the bot is waiting 5 seconds for the wrong server response.