### PR TITLE
Fix critical path-bug

### DIFF
--- a/Application/RSBot.Replacer/Program.cs
+++ b/Application/RSBot.Replacer/Program.cs
@@ -10,9 +10,10 @@ namespace RSBot.Replacer
     {
         private static void Main()
         {
+            var startupPath = Application.StartupPath;
             try
             {
-                var tempDirectory = Path.Combine(Environment.CurrentDirectory, "rsbot_download_temp");
+                var tempDirectory = Path.Combine(startupPath, "rsbot_download_temp");
                 var zipFilePath = tempDirectory + "\\latest.zip";
 
                 if (Directory.Exists(tempDirectory) && File.Exists(zipFilePath))
@@ -20,10 +21,11 @@ namespace RSBot.Replacer
                     ZipFile.ExtractToDirectory(zipFilePath, tempDirectory);
 
                     File.Delete(zipFilePath);
-                    CopyDir(tempDirectory, Environment.CurrentDirectory);
+                    CopyDir(tempDirectory, startupPath);
                     Directory.Delete(tempDirectory, true);
                 }
-                Process.Start(Environment.CurrentDirectory + "\\RSBot.exe");
+
+                Process.Start(Path.Combine(startupPath, "RSBot.exe"));
             }
             catch (Exception ex)
             {

--- a/Application/RSBot/Views/SplashScreen.cs
+++ b/Application/RSBot/Views/SplashScreen.cs
@@ -7,7 +7,6 @@ using SDUI.Helpers;
 using System;
 using System.Drawing;
 using System.IO;
-using System.Reflection;
 using System.Windows.Forms;
 
 namespace RSBot.Views
@@ -23,7 +22,7 @@ namespace RSBot.Views
         {
             InitializeComponent();
             CheckForIllegalCrossThreadCalls = false;
-            _mainForm = new Main();
+            _mainForm = new();
 
             labelVersion.Text = Program.AssemblyVersion;
             referenceDataLoader.RunWorkerCompleted += ReferenceDataLoaderCompleted;
@@ -189,7 +188,7 @@ namespace RSBot.Views
         private void InitializeMap()
         {
             //---- Load Map ----
-            var mapFile = Path.Combine(Environment.CurrentDirectory, "Data", "Game", "map.rsc");
+            var mapFile = Path.Combine(Kernel.BasePath, "Data", "Game", "map.rsc");
             
             if (!CollisionManager.Enabled)
             {

--- a/Application/RSBot/Views/Updater.cs
+++ b/Application/RSBot/Views/Updater.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using RSBot.Core;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -26,7 +27,7 @@ namespace RSBot.Views
         /// <summary>
         /// Update address
         /// </summary>
-        private string _updateUrl = "https://rsbot.dev/resouces/update";
+        private string _updateUrl = "https://rsbot.app/update";
 
         /// <summary>
         /// Get current version
@@ -45,7 +46,7 @@ namespace RSBot.Views
 
         private void _Client_DownloadFileCompleted(object sender, AsyncCompletedEventArgs e)
         {
-            Process.Start(Environment.CurrentDirectory + "\\Replacer.exe");
+            Process.Start(Kernel.BasePath + "\\Replacer.exe");
             Environment.Exit(0);
         }
 
@@ -74,7 +75,7 @@ namespace RSBot.Views
                 cbChangeLog.Checked = false;
                 centerPanel.Visible = false;
                 lblInfo.Text = "Downloading updates ...";
-                var tempDirectory = Path.Combine(Environment.CurrentDirectory, "rsbot_download_temp");
+                var tempDirectory = Path.Combine(Kernel.BasePath, "rsbot_download_temp");
 
                 if (!Directory.Exists(tempDirectory))
                     Directory.CreateDirectory(tempDirectory).Attributes = FileAttributes.Directory | FileAttributes.Hidden;

--- a/Library/RSBot.Core/Components/ClientManager.cs
+++ b/Library/RSBot.Core/Components/ClientManager.cs
@@ -36,7 +36,7 @@ namespace RSBot.Core.Components
                 GlobalConfig.Get<string>("RSBot.SilkroadExecutable")
             );
 
-            var buffer = Encoding.UTF8.GetBytes(Path.Combine(Environment.CurrentDirectory, "Client.Library.dll"));
+            var buffer = Encoding.UTF8.GetBytes(Path.Combine(Kernel.BasePath, "Client.Library.dll"));
             var pathLen = (uint)buffer.Length;
 
             var gatewayIndex = GlobalConfig.Get<byte>("RSBot.GatewayIndex");

--- a/Library/RSBot.Core/Components/CollisionManager.cs
+++ b/Library/RSBot.Core/Components/CollisionManager.cs
@@ -100,7 +100,7 @@ public static class CollisionManager
     {
         var sw = Stopwatch.StartNew();
 
-        using var fileStream = new BinaryReader(File.OpenRead(Path.Combine(Environment.CurrentDirectory, "Data", "Game", "map.rsc")));
+        using var fileStream = new BinaryReader(File.OpenRead(Path.Combine(Kernel.BasePath, "Data", "Game", "map.rsc")));
 
         var header = fileStream.ReadString();
         var version = fileStream.ReadInt32();
@@ -142,7 +142,7 @@ public static class CollisionManager
 
         var sw = Stopwatch.StartNew();
 
-        using var fileStream = new BinaryReader(File.OpenRead(Path.Combine(Environment.CurrentDirectory, "Data", "Game", "map.rsc")));
+        using var fileStream = new BinaryReader(File.OpenRead(Path.Combine(Kernel.BasePath, "Data", "Game", "map.rsc")));
         
         _loadedCollisions = new Dictionary<Region, RSCollisionMesh>(regions.Length);
 

--- a/Library/RSBot.Core/Components/LanguageManager.cs
+++ b/Library/RSBot.Core/Components/LanguageManager.cs
@@ -12,7 +12,7 @@ namespace RSBot.Core.Components
 
     public class LanguageManager
     {
-        private static string _path = Path.Combine(Environment.CurrentDirectory, "Data", "Languages");
+        private static string _path = Path.Combine(Kernel.BasePath, "Data", "Languages");
 
         /// <summary>
         /// Parsed language values

--- a/Library/RSBot.Core/Components/ProfileManager.cs
+++ b/Library/RSBot.Core/Components/ProfileManager.cs
@@ -163,17 +163,17 @@ namespace RSBot.Core.Components
         /// <returns></returns>
         public static string GetProfileConfigFileName()
         {
-            return Path.Combine(Environment.CurrentDirectory, "User", "Profiles.rs");
+            return Path.Combine(Kernel.BasePath, "User", "Profiles.rs");
         }
 
         public static string GetProfileFile(string profileName)
         {
-            return Path.Combine(Environment.CurrentDirectory, "User", $"{profileName}.rs");
+            return Path.Combine(Kernel.BasePath, "User", $"{profileName}.rs");
         }
 
         public static string GetProfileDirectory(string profileName)
         {
-            return Path.Combine(Environment.CurrentDirectory, "User", profileName);
+            return Path.Combine(Kernel.BasePath, "User", profileName);
         }
     }
 }

--- a/Library/RSBot.Core/Components/ScriptManager.cs
+++ b/Library/RSBot.Core/Components/ScriptManager.cs
@@ -14,7 +14,7 @@ namespace RSBot.Core.Components
         /// <summary>
         /// Gets the initial directory
         /// </summary>
-        public static string InitialDirectory => Path.Combine(Environment.CurrentDirectory, "Data", "Scripts");
+        public static string InitialDirectory => Path.Combine(Kernel.BasePath, "Data", "Scripts");
 
         /// <summary>
         /// Gets or sets the file.

--- a/Library/RSBot.Core/Config/GlobalConfig.cs
+++ b/Library/RSBot.Core/Config/GlobalConfig.cs
@@ -19,7 +19,7 @@ namespace RSBot.Core
         /// </summary>
         public static void Load()
         {
-            var path = Path.Combine(Environment.CurrentDirectory, "User", ProfileManager.SelectedProfile + ".rs");
+            var path = Path.Combine(Kernel.BasePath, "User", ProfileManager.SelectedProfile + ".rs");
 
             _config = new Config(path);
 

--- a/Library/RSBot.Core/Config/PlayerConfig.cs
+++ b/Library/RSBot.Core/Config/PlayerConfig.cs
@@ -12,7 +12,7 @@ namespace RSBot.Core
         /// <summary>
         /// The config directory
         /// </summary>
-        private static string _configDirectory => Path.Combine(Environment.CurrentDirectory, "User", ProfileManager.SelectedProfile);
+        private static string _configDirectory => Path.Combine(Kernel.BasePath, "User", ProfileManager.SelectedProfile);
 
         /// <summary>
         /// The config

--- a/Library/RSBot.Core/Extensions/NativeExtensions.cs
+++ b/Library/RSBot.Core/Extensions/NativeExtensions.cs
@@ -37,6 +37,9 @@ namespace RSBot.Core.Extensions
             out PROCESS_INFORMATION lpProcessInformation
         );
 
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr CreateMutex(IntPtr lpMutexAttributes, bool bInitialOwner, string lpName);
+
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern bool ReadProcessMemory(
             IntPtr hProcess,
@@ -88,7 +91,7 @@ namespace RSBot.Core.Extensions
 
         [DllImport("kernel32.dll")]
         public static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);
-        
+
         [DllImport("kernel32.dll")]
         public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress, uint dwSize, uint dwFreeType);
 
@@ -96,8 +99,8 @@ namespace RSBot.Core.Extensions
         public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
 
         [DllImport("kernel32.dll")]
-        public static extern IntPtr LoadLibrary(string lpFileName); 
-        
+        public static extern IntPtr LoadLibrary(string lpFileName);
+
         [DllImport("kernel32.dll")]
         public static extern IntPtr CreateSemaphore([In] IntPtr lpSemaphoreAttributes, [In] int lInitialCount, [In] int lMaximumCount, [In] IntPtr lpName);
 

--- a/Library/RSBot.Core/Extensions/SocketExtensions.cs
+++ b/Library/RSBot.Core/Extensions/SocketExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -246,6 +247,24 @@ namespace RSBot.Core.Extensions
                 default:
                     return null;
             }
+        }
+        
+        /// <summary>
+         /// Converts a string representing a host name or address to its <see cref="IPAddress"/> representation, 
+         /// optionally opting to return a IpV6 address (defaults to IpV4)
+         /// </summary>
+         /// <param name="hostNameOrAddress">Host name or address to convert into an <see cref="IPAddress"/></param>
+         /// <param name="favorIpV6">When <code>true</code> will return an IpV6 address whenever available, otherwise 
+         /// returns an IpV4 address instead.</param>
+         /// <returns>The <see cref="IPAddress"/> represented by <paramref name="hostNameOrAddress"/> in either IpV4 or
+         /// IpV6 (when available) format depending on <paramref name="favorIpV6"/></returns>
+        public static IPAddress ToIPAddress(this string hostNameOrAddress, bool favorIpV6 = false)
+        {
+            var favoredFamily = favorIpV6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
+            var addrs = Dns.GetHostAddresses(hostNameOrAddress);
+            return addrs.FirstOrDefault(addr => addr.AddressFamily == favoredFamily)
+                   ??
+                   addrs.FirstOrDefault();
         }
     }
 }

--- a/Library/RSBot.Core/Kernel.cs
+++ b/Library/RSBot.Core/Kernel.cs
@@ -59,6 +59,11 @@ namespace RSBot.Core
         public static int TickCount => (Environment.TickCount & int.MaxValue);
 
         /// <summary>
+        /// Get environment base directory
+        /// </summary>
+        public static string BasePath => AppDomain.CurrentDomain.BaseDirectory;
+
+        /// <summary>
         /// Initializes this instance.
         /// </summary>
         public static void Initialize()

--- a/Library/RSBot.Core/Log.cs
+++ b/Library/RSBot.Core/Log.cs
@@ -80,7 +80,7 @@ namespace RSBot.Core
         {
             Warn(obj.Message);
 
-            var filePath = Path.Combine(Environment.CurrentDirectory, "Data", "Logs", "Exceptions", $"{DateTime.Now:dd-MM-yyyy}.txt");
+            var filePath = Path.Combine(Kernel.BasePath, "Data", "Logs", "Exceptions", $"{DateTime.Now:dd-MM-yyyy}.txt");
             if (!Directory.Exists(filePath))
                 Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 

--- a/Library/RSBot.Core/Plugins/BotbaseManager.cs
+++ b/Library/RSBot.Core/Plugins/BotbaseManager.cs
@@ -15,7 +15,7 @@ namespace RSBot.Core.Plugins
         /// <value>
         /// The extension directory.
         /// </value>
-        public string DirectoryPath => Path.Combine(Environment.CurrentDirectory, "Data", "Bots");
+        public string DirectoryPath => Path.Combine(Kernel.BasePath, "Data", "Bots");
 
         /// <summary>
         /// Gets the extensions.
@@ -57,7 +57,7 @@ namespace RSBot.Core.Plugins
             }
             catch (Exception ex)
             {
-                File.WriteAllText(Environment.CurrentDirectory + "\\boot-error.log", $"The botbase manager encountered a problem: \n{ex.Message} at {ex.StackTrace}");
+                File.WriteAllText(Kernel.BasePath + "\\boot-error.log", $"The botbase manager encountered a problem: \n{ex.Message} at {ex.StackTrace}");
                 return false;
             }
         }

--- a/Library/RSBot.Core/Plugins/PluginManager.cs
+++ b/Library/RSBot.Core/Plugins/PluginManager.cs
@@ -16,7 +16,7 @@ namespace RSBot.Core.Plugins
         /// <value>
         /// The extension directory.
         /// </value>
-        public string InitialDirectory => Path.Combine(Environment.CurrentDirectory, "Data", "Plugins");
+        public string InitialDirectory => Path.Combine(Kernel.BasePath, "Data", "Plugins");
 
         /// <summary>
         /// Gets the extensions.
@@ -59,7 +59,7 @@ namespace RSBot.Core.Plugins
             }
             catch (Exception ex)
             {
-                File.WriteAllText(Environment.CurrentDirectory + "\\boot-error.log", $"The plugin manager encountered a problem: \n{ex.Message} at {ex.StackTrace}");
+                File.WriteAllText(Kernel.BasePath + "\\boot-error.log", $"The plugin manager encountered a problem: \n{ex.Message} at {ex.StackTrace}");
                 return false;
             }
         }

--- a/Library/RSBot.Core/RSBot.Core.csproj
+++ b/Library/RSBot.Core/RSBot.Core.csproj
@@ -11,6 +11,7 @@
 	  <PackageProjectUrl>https://github.com/SDClowen/RSBot</PackageProjectUrl>
 	  <PackageReadmeFile></PackageReadmeFile>
 	  <RepositoryUrl>https://github.com/SDClowen/RSBot</RepositoryUrl>
+	  <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Plugins/RSBot.General/Components/Accounts.cs
+++ b/Plugins/RSBot.General/Components/Accounts.cs
@@ -28,7 +28,7 @@ namespace RSBot.General.Components
         /// <summary>
         /// Get the data file path
         /// </summary>
-        private static string _filePath => Path.Combine(Environment.CurrentDirectory, "User", ProfileManager.SelectedProfile, "autologin.data");
+        private static string _filePath => Path.Combine(Kernel.BasePath, "User", ProfileManager.SelectedProfile, "autologin.data");
 
         /// <summary>
         /// Check the saving directory

--- a/Plugins/RSBot.Log/Views/Main.cs
+++ b/Plugins/RSBot.Log/Views/Main.cs
@@ -46,7 +46,7 @@ namespace RSBot.Log.Views
             if (!checkEnabled.Checked) 
                 return;
 
-            var logFile = Path.Combine(Environment.CurrentDirectory, "User", "Logs", Game.Player == null ? "Environment" : Game.Player.Name, $"{DateTime.Now:dd-MM-yyyy}.txt");
+            var logFile = Path.Combine(Kernel.BasePath, "User", "Logs", Game.Player == null ? "Environment" : Game.Player.Name, $"{DateTime.Now:dd-MM-yyyy}.txt");
 
             if (level == LogLevel.Debug && !checkDebug.Checked) 
                 return;


### PR DESCRIPTION
This issue was having a problem with injecting the client and triggering the client library function.
Since v2.6 users have been solving this issue by moving the bot to another disk. It will probably be fixed with this pr.