### PR TITLE
Fix avoidance and preferance checks

### DIFF
--- a/Botbases/RSBot.Default/Bundle/Avoidance/AvoidanceBundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Avoidance/AvoidanceBundle.cs
@@ -1,4 +1,5 @@
-﻿using RSBot.Core;
+﻿using System.Linq;
+using RSBot.Core;
 using RSBot.Core.Objects;
 
 namespace RSBot.Default.Bundle.Avoidance;
@@ -11,7 +12,7 @@ internal class AvoidanceBundle : IBundle
     /// <value>
     ///     The avoidance list.
     /// </value>
-    public MonsterRarity[] AvoidanceList { get; private set; }
+    public MonsterRarity[] AvoidanceList => PlayerConfig.GetEnums<MonsterRarity>("RSBot.Avoidance.Avoid");
 
     /// <summary>
     ///     Gets the preferance list.
@@ -19,7 +20,7 @@ internal class AvoidanceBundle : IBundle
     /// <value>
     ///     The preferance list.
     /// </value>
-    public MonsterRarity[] PreferanceList { get; private set; }
+    public MonsterRarity[] PreferanceList => PlayerConfig.GetEnums<MonsterRarity>("RSBot.Avoidance.Prefer");
 
     /// <summary>
     ///     Invokes this instance.
@@ -33,8 +34,7 @@ internal class AvoidanceBundle : IBundle
     /// </summary>
     public void Refresh()
     {
-        AvoidanceList = PlayerConfig.GetEnums<MonsterRarity>("RSBot.Avoidance.Avoid");
-        PreferanceList = PlayerConfig.GetEnums<MonsterRarity>("RSBot.Avoidance.Prefer");
+
     }
 
     public void Stop()
@@ -47,33 +47,12 @@ internal class AvoidanceBundle : IBundle
     /// </summary>
     /// <param name="rarity">The rarity.</param>
     /// <returns></returns>
-    public bool AvoidMonster(MonsterRarity rarity)
-    {
-        return CheckForRarity(AvoidanceList, rarity);
-    }
+    public bool AvoidMonster(MonsterRarity rarity) => AvoidanceList.Contains(rarity);
 
     /// <summary>
     ///     Prefers the monster.
     /// </summary>
     /// <param name="rarity">The rarity.</param>
     /// <returns></returns>
-    public bool PreferMonster(MonsterRarity rarity)
-    {
-        return CheckForRarity(PreferanceList, rarity);
-    }
-
-    /// <summary>
-    ///     Checks for rarity blacklist.
-    /// </summary>
-    /// <param name="avoidanceList">The avoidance list.</param>
-    /// <param name="rarity">The rarity.</param>
-    /// <returns></returns>
-    public bool CheckForRarity(MonsterRarity[] avoidanceList, MonsterRarity rarity)
-    {
-        foreach (var item in avoidanceList)
-            if ((item & rarity) == rarity)
-                return true;
-
-        return false;
-    }
+    public bool PreferMonster(MonsterRarity rarity) => PreferanceList.Contains(rarity);
 }

--- a/Botbases/RSBot.Default/Bundle/Berzerk/BerzerkBundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Berzerk/BerzerkBundle.cs
@@ -26,6 +26,7 @@ internal class BerzerkBundle : IBundle
         if (Config.WhenFull)
         {
             Game.Player.EnterBerzerkMode();
+
             return;
         }
 
@@ -42,8 +43,7 @@ internal class BerzerkBundle : IBundle
         if (!Config.BeeingAttackedByAwareMonster)
             return;
 
-        var entity = Game.SelectedEntity as SpawnedMonster;
-        if (entity == null)
+        if (Game.SelectedEntity is not SpawnedMonster entity)
             return;
 
         if (Bundles.Avoidance.AvoidMonster(entity.Rarity))

--- a/Botbases/RSBot.Default/Bundle/Buff/BuffBundle.cs
+++ b/Botbases/RSBot.Default/Bundle/Buff/BuffBundle.cs
@@ -18,6 +18,9 @@ internal class BuffBundle : IBundle
         if (_invoked)
             return;
 
+        if (Game.Player.Untouchable || Game.Player.InAction)
+            return;
+
         try
         {
             _invoked = true;

--- a/Library/RSBot.Core/Client/ReferenceObjects/RefSkill.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/RefSkill.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
-using System.IO;
+using System.Linq;
 using RSBot.Core.Extensions;
 using RSBot.Core.Objects;
 
@@ -144,6 +144,8 @@ public class RefSkill : IReference<uint>
     //public byte AI_SkillType;
     public List<int> Params = new(50);
 
+    public PrimarySkillParam Type => (PrimarySkillParam) Params[0];
+
     #endregion Fields
 
     #region IReference
@@ -237,7 +239,6 @@ public class RefSkill : IReference<uint>
 
         //AI_AttackChance = short.Parse(data[66]);
         //AI_SkillType = byte.Parse(data[67]);
-
         for (var i = 0; i < PARAM_COUNT; i++)
             if (parser.TryParse(68 + i, out int paramValue))
                 Params.Add(paramValue);

--- a/Library/RSBot.Core/Client/ReferenceObjects/SkillParams.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/SkillParams.cs
@@ -1,0 +1,10 @@
+﻿namespace RSBot.Core.Client.ReferenceObjects;
+
+public enum PrimarySkillParam: int
+{
+    Meele = 0,
+    Ranged = 1,
+    Reserved = 2, //Unknown / not used
+    Buff = 3,
+    Passive = 4
+}

--- a/Library/RSBot.Core/Network/Handler/Agent/Entity/EntityUpdateStateResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Entity/EntityUpdateStateResponse.cs
@@ -86,7 +86,7 @@ internal class EntityUpdateStateResponse : IPacketHandler
             case 4:
 
                 entity.State.BodyState = (BodyState)state;
-
+                
                 EventManager.FireEvent("OnUpdateEntityBodyState", uniqueId);
                 break;
 

--- a/Library/RSBot.Core/Network/Handler/Agent/Game/BuffTokenUpdateResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Game/BuffTokenUpdateResponse.cs
@@ -53,15 +53,4 @@ internal class BuffTokenUpdateResponse : IPacketHandler
             skillInfo?.SetCoolDown(milliseconds);
         }
     }
-
-    /// <summary>
-    ///     Handles the Elapsed event of the UntouchableTimer control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="ElapsedEventArgs" /> instance containing the event data.</param>
-    private void UntouchableTimer_Elapsed(object sender, ElapsedEventArgs e)
-    {
-        Log.Debug("The player is no longer untouchable");
-        Game.Player.Untouchable = false;
-    }
 }

--- a/Library/RSBot.Core/Objects/Player.cs
+++ b/Library/RSBot.Core/Objects/Player.cs
@@ -528,7 +528,7 @@ public class Player : SpawnedBionic
     /// <value>
     ///     <c>true</c> if untouchable; otherwise, <c>false</c>.
     /// </value>
-    public bool Untouchable { get; set; }
+    public bool Untouchable => State.BodyState == BodyState.Untouchable;
 
     /// <summary>
     ///     Gets or sets a value indicating whether this <see cref="Player" /> is exchanging.

--- a/Plugins/RSBot.CommandCenter/Components/Emoticons.cs
+++ b/Plugins/RSBot.CommandCenter/Components/Emoticons.cs
@@ -10,13 +10,13 @@ internal static class Emoticons
 {
     public static List<EmoticonItem> Items => new()
     {
-        new EmoticonItem("emoticon.hi", "Hi", "emot_act_greeting.ddj", EmoticonType.Hi),
-        new EmoticonItem("emoticon.smile", "Smile", "emot_act_laugh.ddj", EmoticonType.Smile),
-        new EmoticonItem("emoticon.greeting", "Greeting", "emot_act_pokun.ddj", EmoticonType.Greeting),
-        new EmoticonItem("emoticon.yes", "Yes", "emot_act_yes.ddj", EmoticonType.Yes),
-        new EmoticonItem("emoticon.rush", "Rush", "emot_act_rush.ddj", EmoticonType.Rush),
-        new EmoticonItem("emoticon.joy", "Joy", "emot_act_joy.ddj", EmoticonType.Joy),
-        new EmoticonItem("emoticon.no", "No", "emot_act_no.ddj", EmoticonType.No)
+        new EmoticonItem("emoticon.hi", "Hi", "icon\\action\\emot_act_greeting.ddj", EmoticonType.Hi),
+        new EmoticonItem("emoticon.smile", "Smile", "icon\\action\\emot_act_laugh.ddj", EmoticonType.Smile),
+        new EmoticonItem("emoticon.greeting", "Greeting", "icon\\action\\emot_act_pokun.ddj", EmoticonType.Greeting),
+        new EmoticonItem("emoticon.yes", "Yes", "icon\\action\\emot_act_yes.ddj", EmoticonType.Yes),
+        new EmoticonItem("emoticon.rush", "Rush", "icon\\action\\emot_act_rush.ddj", EmoticonType.Rush),
+        new EmoticonItem("emoticon.joy", "Joy", "icon\\action\\emot_act_joy.ddj", EmoticonType.Joy),
+        new EmoticonItem("emoticon.no", "No", "icon\\action\\emot_act_no.ddj", EmoticonType.No)
     };
 
     public static string GetEmoticonDefaultCommand(string emoticonName)
@@ -53,7 +53,10 @@ internal record EmoticonItem(string Name, string Label, string Icon, EmoticonTyp
 {
     public Image GetIconImage()
     {
-        return Game.MediaPk2.FileExists(Icon) ? Game.MediaPk2.GetFile(Icon).ToImage() : new Bitmap(32, 32);
+        if (!Game.MediaPk2.TryGetFile(Icon, out var iconFile))
+            return new Bitmap(32, 32);
+
+        return iconFile.ToImage();
     }
 
     public override string ToString()

--- a/Plugins/RSBot.Inventory/Views/Main.cs
+++ b/Plugins/RSBot.Inventory/Views/Main.cs
@@ -72,23 +72,26 @@ public partial class Main : UserControl
         if (!listViewMain.Items.ContainsKey(key))
             return;
 
-        var inventoryItem = Game.Player.Inventory.GetItemAt(slot);
-        if (inventoryItem == null)
-            return;
+        lock (_lock)
+        {
+            var inventoryItem = Game.Player.Inventory.GetItemAt(slot);
+            if (inventoryItem == null)
+                return;
 
-        var listViewItem = listViewMain.Items[key];
+            var listViewItem = listViewMain.Items[key];
 
-        var name = inventoryItem.Record.GetRealName();
-        if (inventoryItem.OptLevel > 0)
-            name += " (+" + inventoryItem.OptLevel + ")";
+            var name = inventoryItem.Record.GetRealName();
+            if (inventoryItem.OptLevel > 0)
+                name += " (+" + inventoryItem.OptLevel + ")";
 
-        listViewItem.SubItems[0].Text = name;
-        listViewItem.SubItems[1].Text = inventoryItem.Amount.ToString();
+            listViewItem.SubItems[0].Text = name;
+            listViewItem.SubItems[1].Text = inventoryItem.Amount.ToString();
 
-        if (inventoryItem.Record.IsEquip)
-            listViewItem.SubItems[2].Text = inventoryItem.Record.GetRarityName();
+            if (inventoryItem.Record.IsEquip)
+                listViewItem.SubItems[2].Text = inventoryItem.Record.GetRarityName();
 
-        listViewItem.LoadItemImageAsync(inventoryItem.Record);
+            listViewItem.LoadItemImageAsync(inventoryItem.Record);
+        }
     }
 
     /// <summary>

--- a/Plugins/RSBot.Items/Views/Main.Designer.cs
+++ b/Plugins/RSBot.Items/Views/Main.Designer.cs
@@ -483,7 +483,7 @@ namespace RSBot.Items.Views
             checkSellItemsFromPet.TabIndex = 3;
             checkSellItemsFromPet.Text = "Sell items from pet";
             checkSellItemsFromPet.UseVisualStyleBackColor = false;
-            checkSellItemsFromPet.CheckedChanged += checkSellItemsFromPet_CheckedChanged;
+            checkSellItemsFromPet.CheckedChanged += checkShoppingSetting_CheckedChanged;
             // 
             // checkStoreItemsFromPet
             // 
@@ -501,7 +501,7 @@ namespace RSBot.Items.Views
             checkStoreItemsFromPet.TabIndex = 4;
             checkStoreItemsFromPet.Text = "Store items from pet";
             checkStoreItemsFromPet.UseVisualStyleBackColor = false;
-            checkStoreItemsFromPet.CheckedChanged += checkStoreItemsFromPet_CheckedChanged;
+            checkStoreItemsFromPet.CheckedChanged += checkShoppingSetting_CheckedChanged;
             // 
             // checkRepairGear
             // 
@@ -519,7 +519,7 @@ namespace RSBot.Items.Views
             checkRepairGear.TabIndex = 1;
             checkRepairGear.Text = "Automaticaly repair all gear";
             checkRepairGear.UseVisualStyleBackColor = false;
-            checkRepairGear.CheckedChanged += checkRepairGear_CheckedChanged;
+            checkRepairGear.CheckedChanged += checkShoppingSetting_CheckedChanged;
             // 
             // checkEnable
             // 
@@ -537,7 +537,7 @@ namespace RSBot.Items.Views
             checkEnable.TabIndex = 0;
             checkEnable.Text = "Automaticaly run when in town";
             checkEnable.UseVisualStyleBackColor = false;
-            checkEnable.CheckedChanged += checkEnable_CheckedChanged;
+            checkEnable.CheckedChanged += checkShoppingSetting_CheckedChanged;
             // 
             // tabSellFilter
             // 
@@ -1605,7 +1605,7 @@ namespace RSBot.Items.Views
             groupBoxOptions.Radius = 10;
             groupBoxOptions.ShadowDepth = 4;
             groupBoxOptions.Size = new Size(734, 100);
-            groupBoxOptions.TabIndex = 6;
+            groupBoxOptions.TabIndex = 0;
             groupBoxOptions.TabStop = false;
             groupBoxOptions.Text = "Options";
             // 
@@ -1625,7 +1625,7 @@ namespace RSBot.Items.Views
             checkPickupGold.TabIndex = 0;
             checkPickupGold.Text = "Pickup gold";
             checkPickupGold.UseVisualStyleBackColor = false;
-            checkPickupGold.CheckedChanged += checkPickupGold_CheckedChanged;
+            checkPickupGold.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkAllEquips
             // 
@@ -1638,10 +1638,10 @@ namespace RSBot.Items.Views
             checkAllEquips.Name = "checkAllEquips";
             checkAllEquips.Ripple = true;
             checkAllEquips.Size = new Size(148, 30);
-            checkAllEquips.TabIndex = 5;
+            checkAllEquips.TabIndex = 4;
             checkAllEquips.Text = "Pickup all equip items";
             checkAllEquips.UseVisualStyleBackColor = false;
-            checkAllEquips.CheckedChanged += checkAllEquips_CheckedChanged;
+            checkAllEquips.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkEverything
             // 
@@ -1654,10 +1654,10 @@ namespace RSBot.Items.Views
             checkEverything.Name = "checkEverything";
             checkEverything.Ripple = true;
             checkEverything.Size = new Size(126, 30);
-            checkEverything.TabIndex = 4;
+            checkEverything.TabIndex = 5;
             checkEverything.Text = "Pickup everything";
             checkEverything.UseVisualStyleBackColor = false;
-            checkEverything.CheckedChanged += checkEverything_CheckedChanged;
+            checkEverything.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkPickupRare
             // 
@@ -1672,10 +1672,10 @@ namespace RSBot.Items.Views
             checkPickupRare.Name = "checkPickupRare";
             checkPickupRare.Ripple = true;
             checkPickupRare.Size = new Size(164, 30);
-            checkPickupRare.TabIndex = 1;
+            checkPickupRare.TabIndex = 3;
             checkPickupRare.Text = "Always pickup rare items";
             checkPickupRare.UseVisualStyleBackColor = false;
-            checkPickupRare.CheckedChanged += checkPickupRare_CheckedChanged;
+            checkPickupRare.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkQuestItems
             // 
@@ -1688,10 +1688,10 @@ namespace RSBot.Items.Views
             checkQuestItems.Name = "checkQuestItems";
             checkQuestItems.Ripple = true;
             checkQuestItems.Size = new Size(132, 30);
-            checkQuestItems.TabIndex = 4;
+            checkQuestItems.TabIndex = 2;
             checkQuestItems.Text = "Pickup quest items";
             checkQuestItems.UseVisualStyleBackColor = false;
-            checkQuestItems.CheckedChanged += checkQuestItems_CheckedChanged;
+            checkQuestItems.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkPickupBlue
             // 
@@ -1707,7 +1707,7 @@ namespace RSBot.Items.Views
             checkPickupBlue.TabIndex = 1;
             checkPickupBlue.Text = "Always pickup blue items";
             checkPickupBlue.UseVisualStyleBackColor = false;
-            checkPickupBlue.CheckedChanged += checkPickupBlue_CheckedChanged;
+            checkPickupBlue.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // groupBoxGeneral
             // 
@@ -1741,7 +1741,7 @@ namespace RSBot.Items.Views
             cbDontPickupWhileBotting.TabIndex = 3;
             cbDontPickupWhileBotting.Text = "Don't pickup items while botting";
             cbDontPickupWhileBotting.UseVisualStyleBackColor = false;
-            cbDontPickupWhileBotting.CheckedChanged += cbDontPickupWhileBotting_CheckedChanged;
+            cbDontPickupWhileBotting.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // cbJustpickmyitems
             // 
@@ -1757,7 +1757,7 @@ namespace RSBot.Items.Views
             cbJustpickmyitems.TabIndex = 1;
             cbJustpickmyitems.Text = "Just pick my items";
             cbJustpickmyitems.UseVisualStyleBackColor = false;
-            cbJustpickmyitems.CheckedChanged += cbJustpickmyitems_CheckedChanged;
+            cbJustpickmyitems.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkDontPickupInBerzerk
             // 
@@ -1774,7 +1774,7 @@ namespace RSBot.Items.Views
             checkDontPickupInBerzerk.TabIndex = 2;
             checkDontPickupInBerzerk.Text = "Don't pickup items in berzerk mode";
             checkDontPickupInBerzerk.UseVisualStyleBackColor = false;
-            checkDontPickupInBerzerk.CheckedChanged += checkDontPickupInBerzerk_CheckedChanged;
+            checkDontPickupInBerzerk.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // checkEnableAbilityPet
             // 
@@ -1789,10 +1789,10 @@ namespace RSBot.Items.Views
             checkEnableAbilityPet.Name = "checkEnableAbilityPet";
             checkEnableAbilityPet.Ripple = true;
             checkEnableAbilityPet.Size = new Size(195, 30);
-            checkEnableAbilityPet.TabIndex = 1;
+            checkEnableAbilityPet.TabIndex = 0;
             checkEnableAbilityPet.Text = "Use ability pet to pickup items ";
             checkEnableAbilityPet.UseVisualStyleBackColor = false;
-            checkEnableAbilityPet.CheckedChanged += checkEnableAbilityPet_CheckedChanged;
+            checkEnableAbilityPet.CheckedChanged += checkPickupSettings_CheckedChanged;
             // 
             // Main
             // 
@@ -1803,7 +1803,6 @@ namespace RSBot.Items.Views
             Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
             Name = "Main";
             Size = new Size(754, 473);
-            Load += Main_Load;
             contextShoppingList.ResumeLayout(false);
             contextAvailableProducts.ResumeLayout(false);
             tabMain.ResumeLayout(false);

--- a/Plugins/RSBot.Items/Views/Main.cs
+++ b/Plugins/RSBot.Items/Views/Main.cs
@@ -25,12 +25,15 @@ public partial class Main : UserControl
     private List<RefShopGroup> _protectorTrader;
     private List<RefShopGroup> _stableKeeper;
     private List<RefShopGroup> _weaponTrader;
+    private bool _loadingSettings;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="Main" /> class.
     /// </summary>
     public Main()
     {
+        CheckForIllegalCrossThreadCalls = false;
+
         InitializeComponent();
         SubscribeEvents();
 
@@ -44,7 +47,7 @@ public partial class Main : UserControl
     private void SubscribeEvents()
     {
         EventManager.SubscribeEvent("OnLoadGameData", OnLoadGameData);
-        EventManager.SubscribeEvent("OnLoadCharacter", LoadSettings);
+        EventManager.SubscribeEvent("OnEnterGame", LoadSettings);
     }
 
     /// <summary>
@@ -147,7 +150,7 @@ public partial class Main : UserControl
                 if (filter != "" && !realItemName.Contains(filter)) continue;
 
                 var listItem = new ListViewItem(realItemName)
-                    { Tag = good, Name = item.CodeName, Group = listAvailableProducts.Groups[tabName] };
+                { Tag = good, Name = item.CodeName, Group = listAvailableProducts.Groups[tabName] };
                 listItem.LoadItemImageAsync(good);
 
                 if (!listAvailableProducts.Items.ContainsKey(item.CodeName))
@@ -341,30 +344,30 @@ public partial class Main : UserControl
         }
 
         for (var x = 0; x < 3; x++)
-        for (var z = 0; z < 2; z++)
-        {
-            var cloth = clothTypes[x, z];
-            if (cloth == 0)
-                continue;
+            for (var z = 0; z < 2; z++)
+            {
+                var cloth = clothTypes[x, z];
+                if (cloth == 0)
+                    continue;
 
-            if (checkHead.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 1));
+                if (checkHead.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 1));
 
-            if (checkShoulder.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 2));
+                if (checkShoulder.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 2));
 
-            if (checkChest.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 3));
+                if (checkChest.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 3));
 
-            if (checkLegs.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 4));
+                if (checkLegs.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 4));
 
-            if (checkHand.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 5));
+                if (checkHand.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 5));
 
-            if (checkBoot.Checked)
-                filters.Add(new TypeIdFilter(3, 1, cloth, 6));
-        }
+                if (checkBoot.Checked)
+                    filters.Add(new TypeIdFilter(3, 1, cloth, 6));
+            }
 
         #region Accessory
 
@@ -559,31 +562,38 @@ public partial class Main : UserControl
     /// </summary>
     private void LoadSettings()
     {
-        checkEnable.Checked = PlayerConfig.Get("RSBot.Shopping.Enabled", true);
-        checkRepairGear.Checked = PlayerConfig.Get("RSBot.Shopping.RepairGear", true);
-        checkSellItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.SellPetItems", true);
-        checkPickupGold.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Gold", true);
-        checkPickupRare.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Rare", true);
-        checkPickupBlue.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Blue", true);
-        checkEnableAbilityPet.Checked = PlayerConfig.Get("RSBot.Items.Pickup.EnableAbilityPet", true);
-        checkStoreItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.StorePetItems", true);
-        checkDontPickupInBerzerk.Checked = PlayerConfig.Get("RSBot.Items.Pickup.DontPickupInBerzerk", true);
-        cbJustpickmyitems.Checked = PlayerConfig.Get("RSBot.Items.Pickup.JustPickMyItems", false);
-        cbDontPickupWhileBotting.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.DontPickupWhileBotting");
+        _loadingSettings = true;
 
-        checkQuestItems.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.Quest");
-        checkAllEquips.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.AnyEquips");
-        checkEverything.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.Everything");
+        Invoke(() =>
+        {
+            checkEnable.Checked = PlayerConfig.Get("RSBot.Shopping.Enabled", true);
+            checkRepairGear.Checked = PlayerConfig.Get("RSBot.Shopping.RepairGear", true);
+            checkSellItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.SellPetItems", true);
+            checkPickupGold.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Gold", true);
+            checkPickupRare.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Rare", true);
+            checkPickupBlue.Checked = PlayerConfig.Get("RSBot.Items.Pickup.Blue", true);
+            checkEnableAbilityPet.Checked = PlayerConfig.Get("RSBot.Items.Pickup.EnableAbilityPet", true);
+            checkStoreItemsFromPet.Checked = PlayerConfig.Get("RSBot.Shopping.StorePetItems", true);
+            checkDontPickupInBerzerk.Checked = PlayerConfig.Get("RSBot.Items.Pickup.DontPickupInBerzerk", true);
+            cbJustpickmyitems.Checked = PlayerConfig.Get("RSBot.Items.Pickup.JustPickMyItems", false);
+            cbDontPickupWhileBotting.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.DontPickupWhileBotting");
 
-        ShoppingManager.Enabled = checkEnable.Checked;
-        ShoppingManager.RepairGear = checkRepairGear.Checked;
-        ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
-        ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
+            checkQuestItems.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.Quest", true);
+            checkAllEquips.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.AnyEquips");
+            checkEverything.Checked = PlayerConfig.Get<bool>("RSBot.Items.Pickup.Everything");
 
-        LoadShoppingList();
+            ShoppingManager.Enabled = checkEnable.Checked;
+            ShoppingManager.RepairGear = checkRepairGear.Checked;
+            ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
+            ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
 
-        ShoppingManager.LoadFilters();
-        PickupManager.LoadFilter();
+            LoadShoppingList();
+
+            ShoppingManager.LoadFilters();
+            PickupManager.LoadFilter();
+        });
+
+        _loadingSettings = false;
     }
 
     private async void txtSellSearch_KeyDown(object sender, KeyEventArgs e)
@@ -613,28 +623,6 @@ public partial class Main : UserControl
     }
 
     #region Shopping manager
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkSellItemsFromPet control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkSellItemsFromPet_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Shopping.SellPetItems", checkSellItemsFromPet.Checked);
-        ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkStoreItemsFromPet control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkStoreItemsFromPet_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Shopping.StorePetItems", checkSellItemsFromPet.Checked);
-        ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
-    }
 
     /// <summary>
     ///     Handles the SelectedIndexChanged event of the comboStore control.
@@ -721,26 +709,23 @@ public partial class Main : UserControl
         SaveShoppingList();
     }
 
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkEnable control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkEnable_CheckedChanged(object sender, EventArgs e)
-    {
-        ShoppingManager.Enabled = checkEnable.Checked;
-        PlayerConfig.Set("RSBot.Shopping.Enabled", checkEnable.Checked);
-    }
 
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkRepairGear control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkRepairGear_CheckedChanged(object sender, EventArgs e)
+    private void checkShoppingSetting_CheckedChanged(object sender, EventArgs e)
     {
+        if (_loadingSettings)
+            return;
+
         ShoppingManager.RepairGear = checkRepairGear.Checked;
         PlayerConfig.Set("RSBot.Shopping.RepairGear", checkRepairGear.Checked);
+
+        ShoppingManager.Enabled = checkEnable.Checked;
+        PlayerConfig.Set("RSBot.Shopping.Enabled", checkEnable.Checked);
+
+        PlayerConfig.Set("RSBot.Shopping.StorePetItems", checkSellItemsFromPet.Checked);
+        ShoppingManager.StorePetItems = checkStoreItemsFromPet.Checked;
+
+        PlayerConfig.Set("RSBot.Shopping.SellPetItems", checkSellItemsFromPet.Checked);
+        ShoppingManager.SellPetItems = checkSellItemsFromPet.Checked;
     }
 
     /// <summary>
@@ -890,8 +875,8 @@ public partial class Main : UserControl
     private void btnResetFilter_Click(object sender, EventArgs e)
     {
         foreach (var group in filterPanel.Controls.OfType<GroupBox>())
-        foreach (var checkBox in group.Controls.OfType<CheckBox>())
-            checkBox.Checked = false;
+            foreach (var checkBox in group.Controls.OfType<CheckBox>())
+                checkBox.Checked = false;
 
         listFilter.Items.Clear();
         numDegreeFrom.Value = 0;
@@ -904,46 +889,6 @@ public partial class Main : UserControl
     #region Pickup
 
     /// <summary>
-    ///     Handles the CheckedChanged event of the checkPickupGold control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkPickupGold_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.Gold", checkPickupGold.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkPickupRare control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkPickupRare_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.Rare", checkPickupRare.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkPickupBlue control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkPickupBlue_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.Blue", checkPickupBlue.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkEnableAbilityPet control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkEnableAbilityPet_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.EnableAbilityPet", checkEnableAbilityPet.Checked);
-    }
-
-    /// <summary>
     ///     Handles the CheckedChanged event of the checkShowEquipment control.
     /// </summary>
     /// <param name="sender">The source of the event.</param>
@@ -953,75 +898,22 @@ public partial class Main : UserControl
         PopulateProductList(comboStore.SelectedIndex, txtShopSearch.Text);
     }
 
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkDontPickupInBerzerk control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkDontPickupInBerzerk_CheckedChanged(object sender, EventArgs e)
+    private void checkPickupSettings_CheckedChanged(object sender, EventArgs e)
     {
-        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupInBerzerk", checkDontPickupInBerzerk.Checked);
-    }
+        if (_loadingSettings)
+            return;
 
-    /// <summary>
-    ///     Handles the CheckedChanged event of the cbJustpickmyitems control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void cbJustpickmyitems_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.JustPickMyItems", cbJustpickmyitems.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the cbDontPickupWhileAttacking control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void cbDontPickupWhileAttacking_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupWhileAttacking", cbDontPickupWhileBotting.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the cbDontPickupWhileBotting control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void cbDontPickupWhileBotting_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupWhileBotting", cbDontPickupWhileBotting.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkQuestItems control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkQuestItems_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.Quest", checkQuestItems.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkAllEquips control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkAllEquips_CheckedChanged(object sender, EventArgs e)
-    {
-        PlayerConfig.Set("RSBot.Items.Pickup.AnyEquips", checkAllEquips.Checked);
-    }
-
-    /// <summary>
-    ///     Handles the CheckedChanged event of the checkEverything control.
-    /// </summary>
-    /// <param name="sender">The source of the event.</param>
-    /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-    private void checkEverything_CheckedChanged(object sender, EventArgs e)
-    {
         PlayerConfig.Set("RSBot.Items.Pickup.Everything", checkEverything.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.AnyEquips", checkAllEquips.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.Quest", checkQuestItems.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupWhileAttacking", cbDontPickupWhileBotting.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupWhileBotting", cbDontPickupWhileBotting.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.JustPickMyItems", cbJustpickmyitems.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.DontPickupInBerzerk", checkDontPickupInBerzerk.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.EnableAbilityPet", checkEnableAbilityPet.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.Blue", checkPickupBlue.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.Rare", checkPickupRare.Checked);
+        PlayerConfig.Set("RSBot.Items.Pickup.Gold", checkPickupGold.Checked);
     }
-
     #endregion Pickup
 }

--- a/Plugins/RSBot.Items/Views/Main.cs
+++ b/Plugins/RSBot.Items/Views/Main.cs
@@ -44,6 +44,7 @@ public partial class Main : UserControl
     private void SubscribeEvents()
     {
         EventManager.SubscribeEvent("OnLoadGameData", OnLoadGameData);
+        EventManager.SubscribeEvent("OnLoadCharacter", LoadSettings);
     }
 
     /// <summary>
@@ -609,16 +610,6 @@ public partial class Main : UserControl
         btnAddToStore.Checked = ShoppingManager.StoreFilter.Contains(codeName);
         btnPickup.Checked = PickupManager.PickupFilter.Any(p => p.CodeName == codeName && !p.PickOnlyChar);
         btnPickOnlyCharacter.Checked = PickupManager.PickupFilter.Any(p => p.CodeName == codeName && p.PickOnlyChar);
-    }
-
-    /// <summary>
-    ///     Occurs before Main form is displayed.
-    /// </summary>
-    /// <param name="sender"></param>
-    /// <param name="e"></param>
-    private void Main_Load(object sender, EventArgs e)
-    {
-        LoadSettings();
     }
 
     #region Shopping manager

--- a/Plugins/RSBot.Skills/Views/Main.cs
+++ b/Plugins/RSBot.Skills/Views/Main.cs
@@ -459,8 +459,13 @@ public partial class Main : UserControl
             if (player == null)
                 return;
 
-            LoadImbues();
+            LoadTeleportSkills();
             LoadResurrectionSkills();
+            LoadTeleportSkills();
+            LoadImbues();
+            LoadBuffs();
+            LoadMasteries();
+            LoadAttacks(comboMonsterType.SelectedIndex);
 
             listSkills.BeginUpdate();
             listSkills.Items.Clear();
@@ -653,7 +658,6 @@ public partial class Main : UserControl
                 resurrectionSkill = newSkill.Id;
 
             PlayerConfig.Set("RSBot.Skills.ResurrectionSkill", resurrectionSkill);
-            LoadResurrectionSkills();
         }
 
         var selectedImbue = PlayerConfig.Get<uint>("RSBot.Skills.Imbue");
@@ -665,7 +669,6 @@ public partial class Main : UserControl
                 selectedImbue = newSkill.Id;
 
             PlayerConfig.Set("RSBot.Skills.Imbue", selectedImbue);
-            LoadImbues();
         }
 
 
@@ -678,16 +681,9 @@ public partial class Main : UserControl
                 selectedTeleportSkill = newSkill.Id;
 
             PlayerConfig.Set("RSBot.Skills.TeleportSkill", selectedTeleportSkill);
-            LoadTeleportSkills();
         }
 
         LoadSkills();
-
-        ApplyAttackSkills();
-        ApplyBuffSkills();
-
-        LoadAttacks();
-        LoadBuffs();
 
         PlayerConfig.Save();
     }
@@ -734,7 +730,6 @@ public partial class Main : UserControl
     {
         Log.NotifyLang("MasteryUpgraded", info.Record.Name);
 
-        LoadMasteries();
         LoadSkills();
     }
 
@@ -744,11 +739,8 @@ public partial class Main : UserControl
     private void OnLoadCharacter()
     {
         comboMonsterType.SelectedIndex = 0;
+
         LoadSkills();
-        LoadAttacks();
-        LoadBuffs();
-        LoadMasteries();
-        LoadTeleportSkills();
 
         ApplyAttackSkills();
         ApplyBuffSkills();

--- a/Plugins/RSBot.Skills/Views/Main.cs
+++ b/Plugins/RSBot.Skills/Views/Main.cs
@@ -684,6 +684,8 @@ public partial class Main : UserControl
         }
 
         LoadSkills();
+        ApplyAttackSkills();
+        ApplyBuffSkills();
 
         PlayerConfig.Save();
     }

--- a/RSBot.sln
+++ b/RSBot.sln
@@ -36,6 +36,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RSBot.Default", "Botbases\RSBot.Default\RSBot.Default.csproj", "{BDDCA486-B41F-4CB5-AAB8-F15A5BBD0638}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RSBot", "Application\RSBot\RSBot.csproj", "{259A396E-2479-493E-A360-6CAD48E3CB5E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{2512902C-3EF4-4395-9925-258F49A5813B} = {2512902C-3EF4-4395-9925-258F49A5813B}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RSBot.Replacer", "Application\RSBot.Replacer\RSBot.Replacer.csproj", "{EBA7F066-8BD6-488D-A65A-B9FFFF2667C4}"
 EndProject


### PR DESCRIPTION
- Fixes https://github.com/SDClowen/RSBot/issues/737
- Fixes avoid/prefer monster checks
- Fixes a bug where the pickup item filter wasn't loaded until a setting has changed
- Fixes a bug where pickup settings were not loaded after entering the game
- Fixes a bug where the teleportation/resurrection skills would not update in the UI
- Fixes a bug where the bot would buff eventhough the player is untouchable