### PR TITLE
blackrogue dungeoninfo fix

### DIFF
--- a/Library/RSBot.NavMeshApi/Dungeon/DungeonInfo.cs
+++ b/Library/RSBot.NavMeshApi/Dungeon/DungeonInfo.cs
@@ -1,5 +1,4 @@
 ﻿using RSBot.NavMeshApi.Mathematics;
-
 using System.Text.RegularExpressions;
 
 namespace RSBot.NavMeshApi.Dungeon;
@@ -12,40 +11,48 @@ public class DungeonInfo
     {
         _dungeons.Clear();
 
-        using (var reader = new StreamReader(stream))
+        using var reader = new StreamReader(stream);
+
+        while (!reader.EndOfStream)
         {
-            while (!reader.EndOfStream)
+            var line = reader.ReadLine();
+
+            if (string.IsNullOrEmpty(line) || line.StartsWith("//"))
             {
-                var line = reader.ReadLine();
-                if (line.StartsWith("//"))
-                    continue;
-
-                var match = Regex.Match(line, "(?<service>0|1)\\t(?<id>\\d*)\t\"(?<path>.*)\"");
-
-                var data = line.Split('\t');
-                if (!int.TryParse(match.Groups["service"].Value, out int service))
-                    throw new Exception($"Failed to load dungeon info: malformed service on {line}");
-
-                if (!short.TryParse(match.Groups["id"].Value, out short dungeonId))
-                    throw new Exception($"Failed to load dungeon info: malformed id on {line}");
-
-                var dungeonPath = match.Groups["path"].Value;
-                if (string.IsNullOrEmpty(dungeonPath))
-                    throw new Exception($"Failed to load dungeon info: malformed path on {line}");
-
-                if (service == 0)
-                    continue;
-
-                _dungeons.Add(new RID(dungeonId) { IsDungeon = true }, dungeonPath);
+                continue;
             }
+
+            // We are reading values from the end, because the structure of Data.pk2\Dungeon\dungeoninfo.txt is different for VSRO and BlackRogue for example
+            // VSRO: service    id  path
+            // BlackRogue:   id  path
+            var stack = new Stack<string>(line.Split('\t'));
+
+            var dungeonPath = Regex.Match(stack.Pop(), "\"(?<path>.*)\"").Groups["path"].Value;
+
+            if (string.IsNullOrEmpty(dungeonPath))
+            {
+                throw new Exception($"Failed to load dungeon info: malformed path on {line}");
+            }
+
+            if (!short.TryParse(stack.Pop(), out short dungeonId))
+            {
+                throw new Exception($"Failed to load dungeon info: malformed id on {line}");
+            }
+
+            if (stack.Count > 0 && int.TryParse(stack.Pop(), out int service) && service == 0)
+            {
+                continue;
+            }
+
+            _dungeons.Add(new RID(dungeonId) { IsDungeon = true }, dungeonPath);
         }
     }
 
-    public string this[RID region]
+    public string? this[RID region]
     {
         get
         {
-            if (_dungeons.TryGetValue(region, out string value))
+            if (_dungeons.TryGetValue(region, out string? value))
                 return value;
 
             return null;


### PR DESCRIPTION
When using BlackRogue Cap 100 client the dungeoninfo only has id and dungeonpath, no service.
This causes an exception on loading, and the Player object will be null, and it will cause infinite null reference exceptions