### PR TITLE
Enhance Party System: Add LeaderChange Type and Handle in Party Updates

### DIFF
--- a/Library/RSBot.Core/Network/Handler/Agent/Party/PartyUpdateResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Party/PartyUpdateResponse.cs
@@ -114,6 +114,11 @@ internal class PartyUpdateResponse : IPacketHandler
                 EventManager.FireEvent("OnPartyLeaderChange");
                 break;
 
+            case PartyUpdateType.LeaderChange:
+                Game.Party.Leader = Game.Party.GetMemberById(packet.ReadUInt());
+                EventManager.FireEvent("OnPartyLeaderChange");
+                break;
+
             default:
                 Log.Debug($"Unknow party type:{type} opcode: {packet.Opcode}");
                 break;

--- a/Library/RSBot.Core/Objects/Party/PartyUpdateType.cs
+++ b/Library/RSBot.Core/Objects/Party/PartyUpdateType.cs
@@ -6,5 +6,6 @@ internal enum PartyUpdateType
     Joined = 2,
     Leave = 3,
     Member = 6,
-    Leader = 7 // 0x09 ??
+    Leader = 7, // 0x09 ??
+    LeaderChange = 9
 }


### PR DESCRIPTION
This pull request includes updates to the party system in the `RSBot.Core` library. The changes introduce a new `LeaderChange` type and handle this new type in the party update response method.

### Party System Enhancements:

* [`Library/RSBot.Core/Objects/Party/PartyUpdateType.cs`](diffhunk://#diff-f56c051207cc954777f1aab1f5b2292ad5ee04c5f2ee0bf2292fc2742be5ace4L9-R10): Added a new `LeaderChange` type to the `PartyUpdateType` enum.
* [`Library/RSBot.Core/Network/Handler/Agent/Party/PartyUpdateResponse.cs`](diffhunk://#diff-676424346078898190da354e9469cbad8a4021343b9537d34dfb16e4ebb84475R117-R121): Added a case to handle the new `LeaderChange` type in the `PartyUpdateResponseCommon` method, updating the party leader and firing an event.

#### Special Thanks: İlker Baraz