### PR TITLE
Fixed teleporting in clientless and bug with alchemy

### DIFF
--- a/Library/RSBot.Core/Network/Handler/Agent/Alchemy/GenericAlchemyAckResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Alchemy/GenericAlchemyAckResponse.cs
@@ -34,7 +34,10 @@ internal static class GenericAlchemyAckResponse
         }
 
         var isSuccess = packet.ReadBool();
-        packet.ReadByte(); //???
+
+        if (Game.ClientType >= GameClientType.Global)
+            packet.ReadByte(); //???
+
         var slot = packet.ReadByte();
 
         var oldItem = Game.Player.Inventory.GetItemAt(slot);

--- a/Library/RSBot.Core/Network/Handler/Agent/Alchemy/GenericAlchemyAckResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Alchemy/GenericAlchemyAckResponse.cs
@@ -34,6 +34,7 @@ internal static class GenericAlchemyAckResponse
         }
 
         var isSuccess = packet.ReadBool();
+        packet.ReadByte(); //???
         var slot = packet.ReadByte();
 
         var oldItem = Game.Player.Inventory.GetItemAt(slot);

--- a/Library/RSBot.Core/Network/Handler/Agent/Game/GameResetCompleteResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Game/GameResetCompleteResponse.cs
@@ -29,6 +29,11 @@ internal class GameResetRequest : IPacketHandler
         Game.Ready = false;
         Log.Debug("Game client is loading...");
 
+        Packet gameResetResponse = null;
+        if (Game.Clientless)
+            gameResetResponse = new Packet(0x34B6);
+            PacketManager.SendPacket(gameResetResponse, PacketDestination.Server);
+
         if (Game.Player.Teleportation == null)
             return;
 


### PR DESCRIPTION
- Fixed an issue with teleportation in clientless when the bot would get stuck forever waiting for teleportation
- Fixed alchemy result packet structure, as a result alchemy works correctly with +2 and higher enhancing