### PR TITLE
Fix artifact retention period

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -40,6 +40,13 @@ jobs:
           }
           Write-Output "last_sha=$lastSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -NoNewline
 
+      - name: Upload last SHA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: last-sha
+          path: last_sha.txt
+          overwrite: true
+
       - name: Check for new commits
         if: steps.get_sha.outputs.sha == steps.last_sha.outputs.last_sha
         run: |
@@ -77,10 +84,3 @@ jobs:
           files: RSBot.${{ env.date }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload last SHA artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: last-sha
-          path: last_sha.txt
-          overwrite: true


### PR DESCRIPTION
There's a [retention period](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/downloading-workflow-artifacts) for artifacts, they're deleted after 90 days by default.
To ensure that there'll be no duplicate builds after that retention period we have to always upload it.

[Tested](https://github.com/Egezenn/RSBot/actions/runs/14793593957/job/41535782157)