### PR TITLE
Grab pet now works even if the bot is not running

### DIFF
--- a/Botbases/RSBot.Default/Views/Main.Designer.cs
+++ b/Botbases/RSBot.Default/Views/Main.Designer.cs
@@ -741,7 +741,7 @@
             // timerGrabByAbilityPet
             // 
             timerGrabByAbilityPet.Enabled = true;
-            timerGrabByAbilityPet.Interval = 2500;
+            timerGrabByAbilityPet.Interval = 500;
             timerGrabByAbilityPet.Tick += timerGrabByAbilityPet_Tick;
             // 
             // Main

--- a/Botbases/RSBot.Default/Views/Main.Designer.cs
+++ b/Botbases/RSBot.Default/Views/Main.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             System.Windows.Forms.ListViewGroup listViewGroup1 = new System.Windows.Forms.ListViewGroup("Avoid", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup2 = new System.Windows.Forms.ListViewGroup("Prefer", System.Windows.Forms.HorizontalAlignment.Left);
             System.Windows.Forms.ListViewGroup listViewGroup3 = new System.Windows.Forms.ListViewGroup("Berserk", System.Windows.Forms.HorizontalAlignment.Left);
@@ -84,6 +85,7 @@
             linkAttackWeakerMobsHelp = new System.Windows.Forms.LinkLabel();
             checkAttackWeakerFirst = new SDUI.Controls.CheckBox();
             checkBoxDimensionPillar = new SDUI.Controls.CheckBox();
+            timerGrabByAbilityPet = new System.Windows.Forms.Timer(components);
             groupBox2.SuspendLayout();
             ctxAvoidance.SuspendLayout();
             groupBoxWalkback.SuspendLayout();
@@ -736,6 +738,12 @@
             checkBoxDimensionPillar.UseVisualStyleBackColor = false;
             checkBoxDimensionPillar.CheckedChanged += settings_CheckedChanged;
             // 
+            // timerGrabByAbilityPet
+            // 
+            timerGrabByAbilityPet.Enabled = true;
+            timerGrabByAbilityPet.Interval = 2500;
+            timerGrabByAbilityPet.Tick += timerGrabByAbilityPet_Tick;
+            // 
             // Main
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
@@ -807,5 +815,6 @@
         private SDUI.Controls.CheckBox checkAttackWeakerFirst;
         private System.Windows.Forms.LinkLabel linkAttackWeakerMobsHelp;
         private System.Windows.Forms.LinkLabel linkRecord;
+        private System.Windows.Forms.Timer timerGrabByAbilityPet;
     }
 }

--- a/Botbases/RSBot.Default/Views/Main.cs
+++ b/Botbases/RSBot.Default/Views/Main.cs
@@ -4,8 +4,12 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using RSBot.Core;
+using RSBot.Core.Client.ReferenceObjects;
+using RSBot.Core.Components;
 using RSBot.Core.Event;
 using RSBot.Core.Objects;
+using RSBot.Core.Objects.Spawn;
+using RSBot.Default.Bundle;
 using RSBot.Default.Views.Dialogs;
 using SDUI.Controls;
 using CheckBox = SDUI.Controls.CheckBox;
@@ -328,6 +332,14 @@ public partial class Main : DoubleBufferedControl
             item.Group = lvAvoidance.Groups["grpNone"];
 
         SaveAvoidance();
+    }
+
+    private void timerGrabByAbilityPet_Tick(object sender, EventArgs e)
+    {
+        if (Kernel.Bot.Running || !Game.Ready)
+            return;
+        if (Bundles.Loot.Config.UseAbilityPet && Game.Player.HasActiveAbilityPet && !PickupManager.RunningAbilityPetPickup)
+            PickupManager.RunAbilityPet(Game.Player.Position);
     }
 
     /// <summary>

--- a/Library/RSBot.Core/Objects/Cos/Cos.cs
+++ b/Library/RSBot.Core/Objects/Cos/Cos.cs
@@ -209,7 +209,7 @@ public class Cos : SpawnedEntity
             }
 
             return AwaitCallbackResult.Fail;
-        }, 0xB0C5);
+        }, 0xB034); //0xB0C5 in docs but not sent even in 1.188
 
         PacketManager.SendPacket(packet, PacketDestination.Server, callback);
         callback.AwaitResponse();


### PR DESCRIPTION
- Fixed a bug when grab pet was working slowly
- Grab pet now works if the bot is not running but "Use ability pet to pickup items" checkbox enabled