### PR TITLE
Send Gamereset packet in clientless mode only

### DIFF
--- a/Library/RSBot.Core/Network/Handler/Agent/Game/GameResetCompleteResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Game/GameResetCompleteResponse.cs
@@ -29,10 +29,11 @@ internal class GameResetRequest : IPacketHandler
         Game.Ready = false;
         Log.Debug("Game client is loading...");
 
-        Packet gameResetResponse = null;
         if (Game.Clientless)
-            gameResetResponse = new Packet(0x34B6);
+        {
+            Packet gameResetResponse = new Packet(0x34B6);
             PacketManager.SendPacket(gameResetResponse, PacketDestination.Server);
+        }
 
         if (Game.Player.Teleportation == null)
             return;


### PR DESCRIPTION
The intention to send this packet in clientless mode is clearly visible in the code (extra tabs). But the missing brackets causing the bot to send the packet in client mode, causing a null reference error after every teleportation.