### PR TITLE
Change opcode to wait for after executing teleport

### DIFF
--- a/Library/RSBot.Core/Components/Scripting/Commands/TeleportScriptCommand.cs
+++ b/Library/RSBot.Core/Components/Scripting/Commands/TeleportScriptCommand.cs
@@ -78,7 +78,8 @@ internal class TeleportScriptCommand : IScriptCommand
         packet.WriteByte(0x02);
         packet.WriteUInt(destination);
 
-        var callback = new AwaitCallback(null, 0x3012); //Game Ready
+        var gameReadyOpcode = (ushort)(Game.ClientType == GameClientType.Rigid ? 0x3077 : 0x3012);
+        var callback = new AwaitCallback(null, gameReadyOpcode); // Game Ready
         PacketManager.SendPacket(packet, PacketDestination.Server, callback);
 
         callback.AwaitResponse(30_000); //For some really slow PCs


### PR DESCRIPTION
Changed the opcode to wait for after executing teleportation while running a script. Previously, the bot got stuck waiting the 30 seconds timeout before moving on.
Took the other opcode from BuffTokenUpdateResponse packet