### PR TITLE
Fix trading bot on Rigid client

### DIFF
--- a/Botbases/RSBot.Trade/Bundle/RouteBundle.cs
+++ b/Botbases/RSBot.Trade/Bundle/RouteBundle.cs
@@ -44,6 +44,11 @@ internal class RouteBundle
     public bool WaitingForTracePlayer { get; private set; }
 
     /// <summary>
+    ///     A value indicating if the bot is in a state of executing a command
+    /// </summary>
+    public bool ScriptManaggerIsRunning { get => ScriptManager.Running; }
+
+    /// <summary>
     ///     Initializes the bundle.
     /// </summary>
     public void Initialize()

--- a/Botbases/RSBot.Trade/Bundle/TransportBundle.cs
+++ b/Botbases/RSBot.Trade/Bundle/TransportBundle.cs
@@ -70,8 +70,9 @@ internal class TransportBundle
 
     public void Tick()
     {
-        //Summon new transport?
-        if (Game.Player.JobTransport == null)
+        // Summon new transport?
+        if (!Bundles.RouteBundle.ScriptManaggerIsRunning &&
+            Game.Player.JobTransport == null)
         {
             if (Game.Player.State.BattleState == BattleState.InBattle || Game.Player.InAction)
                 return;

--- a/Botbases/RSBot.Trade/TradeBotbase.cs
+++ b/Botbases/RSBot.Trade/TradeBotbase.cs
@@ -91,10 +91,10 @@ public class TradeBotbase : IBotbase
         if (Game.Player == null)
             return false;
 
-        var isUpdatedJobSystem = Game.ClientType >= GameClientType.Chinese;
-        if (!isUpdatedJobSystem && Game.Player.JobInformation is not { Type: JobType.Trade })
+        var gameIsJob2 = Game.ClientType > GameClientType.Vietnam;
+        if (!gameIsJob2 && Game.Player.JobInformation is not { Type: JobType.Trade })
             return false;
-        else if (isUpdatedJobSystem && Game.Player.JobInformation is { Type: JobType.None })
+        else if (gameIsJob2 && Game.Player.JobInformation is { Type: JobType.None })
             return false;
 
         if (Game.Player.Inventory.GetEquippedPartItems().FirstOrDefault(i => i.Record.IsJobOutfit) == null)

--- a/Botbases/RSBot.Trade/TradeBotbase.cs
+++ b/Botbases/RSBot.Trade/TradeBotbase.cs
@@ -44,8 +44,8 @@ public class TradeBotbase : IBotbase
     {
         if (!AssertPlayerIsTrader())
         {
-            MessageBox.Show("The active character is not a trader! Make sure that you have the trader job and suite.",
-                "Not a trader", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            MessageBox.Show("The active character can't trade goods! Make sure that you have the correct job and suite equiped.",
+                "Can't trade", MessageBoxButtons.OK, MessageBoxIcon.Error);
             Kernel.Bot.Stop();
 
             return;
@@ -91,7 +91,10 @@ public class TradeBotbase : IBotbase
         if (Game.Player == null)
             return false;
 
-        if (Game.Player.JobInformation is not { Type: JobType.Trade })
+        var isUpdatedJobSystem = Game.ClientType >= GameClientType.Chinese;
+        if (!isUpdatedJobSystem && Game.Player.JobInformation is not { Type: JobType.Trade })
+            return false;
+        else if (isUpdatedJobSystem && Game.Player.JobInformation is { Type: JobType.None })
             return false;
 
         if (Game.Player.Inventory.GetEquippedPartItems().FirstOrDefault(i => i.Record.IsJobOutfit) == null)


### PR DESCRIPTION
- Allow thiefs to do target trading
- Prevent trader bot from stopping when script tells the bot to teleport (for example at a ferry npc). _(Previously the bot stopped when the JobTransport become null. This happened when teleportation script command started)_