### PR TITLE
Update/fix alchemy bot

### DIFF
--- a/Botbases/RSBot.Alchemy/Bundle/Magic/MagicBundle.cs
+++ b/Botbases/RSBot.Alchemy/Bundle/Magic/MagicBundle.cs
@@ -131,7 +131,7 @@ internal class MagicBundle : IAlchemyBundle
                 continue;
 
             //Gets the current magic option info from the selected item if available
-            var current = config.Item.MagicOptions.FirstOrDefault(m => m.Record.Group == stone.Value.Group);
+            var current = config.Item.MagicOptions.FirstOrDefault(m => m.Record?.Group == stone.Value.Group);
 
             //Enough immortal to fuse the astral stone?
             if (stone.Value.Group == RefMagicOpt.MaterialAstral)

--- a/Botbases/RSBot.Alchemy/Extension/RefMagicOptExtension.cs
+++ b/Botbases/RSBot.Alchemy/Extension/RefMagicOptExtension.cs
@@ -53,7 +53,7 @@ internal static class RefMagicOptExtension
     public static string GetFusingTranslation(this RefMagicOpt magicOption, uint value)
     {
         //TODO: Use and extend GetGroupTranslation instead of hard coding this
-        switch (magicOption.Group)
+        switch (magicOption?.Group)
         {
             case "MATTR_INT":
             case "MATTR_AVATAR_INT":
@@ -153,7 +153,7 @@ internal static class RefMagicOptExtension
                 return $"Maximum durability {value}% Reduce";
         }
 
-        return magicOption.Group;
+        return magicOption?.Group ?? $"Error. Mag. opt. value: {value}";
     }
 
     #endregion Methods

--- a/Botbases/RSBot.Alchemy/Views/Settings/AttributesSettingsView.cs
+++ b/Botbases/RSBot.Alchemy/Views/Settings/AttributesSettingsView.cs
@@ -43,7 +43,8 @@ public partial class AttributesSettingsView : DoubleBufferedControl
                 if (attributePanel.Stones != null && attributePanel.Stones.Any())
                     attributes.Add(new AttributeBundleConfig.AttributeBundleConfigItem
                     {
-                        Group = attributePanel.AttributeGroup, MaxValue = attributePanel.MaxValue,
+                        Group = attributePanel.AttributeGroup,
+                        MaxValue = attributePanel.MaxValue,
                         Stone = attributePanel.Stones.First()
                     });
             }
@@ -99,7 +100,8 @@ public partial class AttributesSettingsView : DoubleBufferedControl
                     Globals.Botbase.AttributeBundleConfig.Attributes.FirstOrDefault(x => x.Group == attributeGroup);
 
                 var panel = new AttributeInfoPanel(attributeGroup, matchingStones, selectedItem,
-                    config == null ? 0 : config.MaxValue) { Dock = DockStyle.Top };
+                    config == null ? 0 : config.MaxValue)
+                { Dock = DockStyle.Top };
                 _attributePanels.Add(panel);
 
                 if (config == null || !matchingStones.Any())
@@ -113,12 +115,13 @@ public partial class AttributesSettingsView : DoubleBufferedControl
                 panel.OnChange += PanelOnChange;
             }
 
-            Hide();
-            Controls.Clear();
-            BeginInvoke(() => {
+            BeginInvoke(() =>
+            {
+                Hide();
+                Controls.Clear();
                 Controls.AddRange(_attributePanels.ToArray());
+                Show();
             });
-            Show();
 
             Globals.Botbase.AttributeBundleConfig = BundleConfig;
         }

--- a/Botbases/RSBot.Alchemy/Views/Settings/AttributesSettingsView.cs
+++ b/Botbases/RSBot.Alchemy/Views/Settings/AttributesSettingsView.cs
@@ -115,7 +115,9 @@ public partial class AttributesSettingsView : DoubleBufferedControl
 
             Hide();
             Controls.Clear();
-            Controls.AddRange(_attributePanels.ToArray());
+            BeginInvoke(() => {
+                Controls.AddRange(_attributePanels.ToArray());
+            });
             Show();
 
             Globals.Botbase.AttributeBundleConfig = BundleConfig;

--- a/Botbases/RSBot.Alchemy/Views/Settings/EnhanceSettingsView.cs
+++ b/Botbases/RSBot.Alchemy/Views/Settings/EnhanceSettingsView.cs
@@ -6,6 +6,7 @@ using System.Windows.Forms;
 using RSBot.Alchemy.Bot;
 using RSBot.Alchemy.Bundle.Enhance;
 using RSBot.Alchemy.Helper;
+using RSBot.Core;
 using RSBot.Core.Event;
 using RSBot.Core.Objects;
 using SDUI.Controls;
@@ -108,7 +109,7 @@ public partial class EnhanceSettingsView : DoubleBufferedControl
         if (armorTypeId3.Contains(_selectedItem.Record.TypeID3) && _selectedItem.Record.TypeID2 == 1)
             type = AlchemyItemHelper.ElixirType.Protector;
 
-        var matchingElixirs = AlchemyItemHelper.GetElixirItems(type);
+        var matchingElixirs = AlchemyItemHelper.GetElixirItems(_selectedItem.Record.Degree, type);
 
         comboElixir.Items.Clear();
 

--- a/Botbases/RSBot.Alchemy/Views/Settings/EnhanceSettingsView.cs
+++ b/Botbases/RSBot.Alchemy/Views/Settings/EnhanceSettingsView.cs
@@ -6,7 +6,6 @@ using System.Windows.Forms;
 using RSBot.Alchemy.Bot;
 using RSBot.Alchemy.Bundle.Enhance;
 using RSBot.Alchemy.Helper;
-using RSBot.Core;
 using RSBot.Core.Event;
 using RSBot.Core.Objects;
 using SDUI.Controls;

--- a/Library/RSBot.Core/Client/ReferenceManager.cs
+++ b/Library/RSBot.Core/Client/ReferenceManager.cs
@@ -48,7 +48,7 @@ public class ReferenceManager
     public List<RefMagicOpt> MagicOptions { get; } = new(1024);
     public List<RefMagicOptAssign> MagicOptionAssignments { get; } = new(128);
 
-    
+
     public void Load(int languageTab, BackgroundWorker worker)
     {
         LanguageTab = languageTab; //until language wizard is reworked?
@@ -140,8 +140,11 @@ public class ReferenceManager
     private void LoadAlchemyData()
     {
         LoadReferenceFile($"{ServerDep}\\magicoption.txt", MagicOptions);
+        if (MagicOptions.Count <= 1)
+        {
+            LoadReferenceFile($"{ServerDep}\\magicoption_all.txt", MagicOptions);
+        }
         LoadReferenceFile($"{ServerDep}\\magicoptionassign.txt", MagicOptionAssignments);
-
     }
 
     private void LoadTeleportData()
@@ -293,7 +296,7 @@ public class ReferenceManager
     {
         if (Game.MediaPk2.TryGetFile(fileName, out var file))
             LoadReferenceListFile(file.OpenRead().GetStream(), destination);
-        
+
     }
 
     private void LoadReferenceListFile<TKey, TReference>(string fileName, IDictionary<TKey, TReference> destination)
@@ -324,7 +327,7 @@ public class ReferenceManager
 
         using var reader = new StreamReader(stream);
         var builder = new StringBuilder(1024);
-        
+
         while (!reader.EndOfStream)
         {
             var line = reader.ReadLineByCRLF(builder);
@@ -357,7 +360,7 @@ public class ReferenceManager
             //Skip invalid
             if (string.IsNullOrEmpty(line) || line.StartsWith("//"))
                 continue;
-                        
+
             filesToLoad.Add(line);
         }
 
@@ -588,12 +591,12 @@ public class ReferenceManager
     public List<RefShopGood> GetRefShopGoods(RefShopGroup group)
     {
         return (from shop in @group.GetShops()
-            where shop != null
-            from tab in shop.GetTabs()
-            where tab != null
-            from good in tab.GetGoods()
-            where good != null
-            select good).ToList();
+                where shop != null
+                from tab in shop.GetTabs()
+                where tab != null
+                from good in tab.GetGoods()
+                where good != null
+                select good).ToList();
     }
 
     public byte GetRefShopGoodTabIndex(string npcCodeName, RefShopGood good)

--- a/Library/RSBot.Core/Client/ReferenceObjects/AlchemyType.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/AlchemyType.cs
@@ -9,5 +9,6 @@ public enum AlchemyType : byte
     AttributeStone = 5,
     AdvancedElixirOrSocketCreate = 8,
     SocketInsert = 9,
-    SocketRemove = 10
+    SocketRemove = 10,
+    EnhancerElixir = 19
 }

--- a/Library/RSBot.Core/Components/AlchemyManager.cs
+++ b/Library/RSBot.Core/Components/AlchemyManager.cs
@@ -65,6 +65,12 @@ public class AlchemyManager
         var itemInInventory = Game.Player.Inventory.GetItemAt(item.Slot);
         var elixirInInventory = Game.Player.Inventory.GetItemAt(elixir.Slot);
         var powderInInventory = Game.Player.Inventory.GetItemAt(powder.Slot);
+        var isProofItem = powderInInventory != null ?
+                new TypeIdFilter(3, 3, 10, 8).EqualsRefItem(powderInInventory?.Record) :
+                false;
+        var alchemyType = isProofItem ?
+                AlchemyType.EnhancerElixir :
+                AlchemyType.Elixir;
 
         if (itemInInventory?.ItemId != item.ItemId ||
             elixirInInventory?.ItemId != elixir.ItemId ||
@@ -81,7 +87,7 @@ public class AlchemyManager
 
         var packet = new Packet(0x7150);
         packet.WriteByte(AlchemyAction.Fuse); //fuse
-        packet.WriteByte(AlchemyType.Elixir); //type (Elixir)
+        packet.WriteByte(alchemyType); // type
         packet.WriteByte(powder != null ? (byte)3 : (byte)2); //Slot count
         packet.WriteByte(item.Slot);
         packet.WriteByte(elixir.Slot);

--- a/Library/RSBot.Core/Components/AlchemyManager.cs
+++ b/Library/RSBot.Core/Components/AlchemyManager.cs
@@ -66,7 +66,7 @@ public class AlchemyManager
         var elixirInInventory = Game.Player.Inventory.GetItemAt(elixir.Slot);
         var powderInInventory = Game.Player.Inventory.GetItemAt(powder.Slot);
         var isProofItem = powderInInventory != null ?
-                new TypeIdFilter(3, 3, 10, 8).EqualsRefItem(powderInInventory?.Record) :
+                new TypeIdFilter(3, 3, 10, 8).EqualsRefItem(powderInInventory!.Record) :
                 false;
         var alchemyType = isProofItem ?
                 AlchemyType.EnhancerElixir :


### PR DESCRIPTION
All three alchemy were failing on Rigid client (in certain cases), this PR resolves all of those issues.

Changes:
- Enhancer understands magic proof stones (lucky powder) and enhancers (elixir)
- Magic option parsing error resolved which prevented the bot from doing any magic option change (or read) automatically
- Resolved attribute changer error where values weren't updated properly, causing the bot to keep going even after reaching the desired value