### PR TITLE
Support for plugins without GUI

### DIFF
--- a/Application/RSBot/Views/Main.cs
+++ b/Application/RSBot/Views/Main.cs
@@ -276,6 +276,13 @@ public partial class Main : UIWindow
     {
         var menuItem = (ToolStripMenuItem)sender;
         var plugin = (IPlugin)menuItem.Tag;
+        var content = plugin.View;
+
+        if (content == null)
+        {
+            Log.Debug($"Plugin [{plugin.InternalName}] does not have a view defined!");
+            return;
+        }
 
         if (!_pluginWindows.TryGetValue(plugin.InternalName, out var pluginWindow) || pluginWindow.IsDisposed)
         {
@@ -290,7 +297,6 @@ public partial class Main : UIWindow
                 ShowTitle = true
             };
 
-            var content = plugin.View;
             content.Dock = DockStyle.Fill;
 
             plugin.Translate();


### PR DESCRIPTION
DisplayAsTab should be false and View should be null. The plugin will still be displayed under the menuStrip gear, but nothing will happen when you click on it