### PR TITLE
March skills added to party buffing for recast

### DIFF
--- a/Library/RSBot.Core/Client/ReferenceObjects/RefSkill.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/RefSkill.cs
@@ -168,7 +168,7 @@ public class RefSkill : IReference<uint>
 
         parser.TryParse(3, out Basic_Code);
         //parser.TryParseString(4, out Basic_Name);
-        //parser.TryParseString(5, out Basic_Group);
+        parser.TryParse(5, out Basic_Group);
         //parser.TryParseInt(6, out Basic_Original);
         parser.TryParse(7, out Basic_Level);
         parser.TryParse(8, out Basic_Activity);

--- a/Plugins/RSBot.Party/Views/Main.Designer.cs
+++ b/Plugins/RSBot.Party/Views/Main.Designer.cs
@@ -1843,7 +1843,7 @@
             checkHideLowerLevelSkills.TabIndex = 10;
             checkHideLowerLevelSkills.Text = "Hide lower level skills";
             checkHideLowerLevelSkills.UseVisualStyleBackColor = false;
-            checkHideLowerLevelSkills.Visible = false;
+            //checkHideLowerLevelSkills.Visible = false;
             checkHideLowerLevelSkills.CheckedChanged += checkHideLowerLevelSkills_CheckedChanged;
             // 
             // Main

--- a/Plugins/RSBot.Party/Views/Main.cs
+++ b/Plugins/RSBot.Party/Views/Main.cs
@@ -387,7 +387,14 @@ public partial class Main : DoubleBufferedControl
         var skills = Game.Player.Skills.KnownSkills
             .Where(s => s.Enabled && s.Record.TargetGroup_Party && !s.Record.TargetEtc_SelectDeadBody);
 
-        foreach (var skill in skills)
+        List<string> additionalGroups = ["SKILL_EU_BARD_SPEEDUPA_MSPEED_A", "SKILL_EU_BARD_SPEEDUPA_MSPEED_B"];
+
+        var additionalSkills = Game.Player.Skills.KnownSkills
+            .Where(s => s.Enabled && additionalGroups.Contains(s.Record.Basic_Group));
+
+        IEnumerable<SkillInfo> partyBuffSkills = skills.Union(additionalSkills);
+
+        foreach (var skill in partyBuffSkills)
         {
             if (skill.IsPassive)
                 continue;


### PR DESCRIPTION
This is useful if someone is absent within the radius during the cast.
The visibility of the "Hide lower level skills" checkbox has also been restored.