### PR TITLE
Fixed riding on pet and using speed scrolls while luring

### DIFF
--- a/Botbases/RSBot.Lure/Bundle/MovementBundle.cs
+++ b/Botbases/RSBot.Lure/Bundle/MovementBundle.cs
@@ -1,10 +1,11 @@
-﻿using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using RSBot.Core;
+﻿using RSBot.Core;
 using RSBot.Core.Components;
 using RSBot.Core.Event;
+using RSBot.Core.Objects;
 using RSBot.Lure.Components;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace RSBot.Lure.Bundle;
 
@@ -12,6 +13,14 @@ internal static class MovementBundle
 {
     public static void Tick()
     {
+        if (LureConfig.UseSpeedDrug &&
+            Game.Player.State.ActiveBuffs.FindIndex(p => p.Record.Params.Contains(1752396901)) < 0)
+        {
+            var item = Game.Player.Inventory.GetItem(new TypeIdFilter(3, 3, 13, 1),
+                p => p.Record.Desc1.Contains("_SPEED_"));
+            item?.Use();
+        }
+
         //Return to center?
         if (LureConfig.Area.Position.DistanceToPlayer() > 5 && LureConfig.StayAtCenterFor && !ScriptManager.Running)
         {

--- a/Botbases/RSBot.Lure/Components/LureConfig.cs
+++ b/Botbases/RSBot.Lure/Components/LureConfig.cs
@@ -6,6 +6,12 @@ namespace RSBot.Lure.Components;
 
 internal static class LureConfig
 {
+    public static bool UseSpeedDrug
+    {
+        get => PlayerConfig.Get("RSBot.Training.checkUseSpeedDrug", true);
+        set => PlayerConfig.Set("RSBot.Training.checkUseSpeedDrug", value);
+    }
+
     public static bool UseHowlingShout
     {
         get => PlayerConfig.Get("RSBot.Lure.UseHowlingShout", false) && Game.Player.Race == ObjectCountry.Europe;

--- a/Library/RSBot.Core/Components/Scripting/Commands/MoveScriptCommand.cs
+++ b/Library/RSBot.Core/Components/Scripting/Commands/MoveScriptCommand.cs
@@ -126,7 +126,8 @@ internal class MoveScriptCommand : IScriptCommand
 
         if (PlayerConfig.Get("RSBot.Training.checkUseMount", true))
         {
-            if (!Game.Player.HasActiveVehicle && !Game.Player.InAction)
+            if (!Game.Player.HasActiveVehicle && !Game.Player.InAction
+                && !(ScriptManager.Running && ScriptManager.File == PlayerConfig.Get("RSBot.Lure.SelectedScriptPath", string.Empty)))
             {
                 Game.Player.SummonFellow();
 


### PR DESCRIPTION
Lure bot is using "Use mount if available" and "Use speed drug" checkboxes from Training botbase.

Now mount is not using during lure script.