### PR TITLE
ci/cd: Redundant nightly releases cleaner

### DIFF
--- a/.github/workflows/clean_nightlies.yml
+++ b/.github/workflows/clean_nightlies.yml
@@ -1,0 +1,20 @@
+name: Delete Old Prereleases
+
+on:
+  schedule:
+    - cron: "0 0 * * 2"
+  workflow_dispatch:
+
+jobs:
+  cleanup-prereleases:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete all but last 2 prereleases
+        uses: jay2610/delete-older-releases@1.0.0
+        with:
+          repo: ${{ github.repository }}
+          keep_latest: 2
+          delete_type: "prerelease"
+          delete_tag_pattern: ""
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tested https://github.com/Egezenn/RSBot/actions/runs/19163408214/job/54778429147

Runs every tuesday, drops the automatically created tags from the releases aswell