### PR TITLE
feat: Implement cli args, don't allow "Profile" creation

### DIFF
--- a/Application/RSBot/Program.cs
+++ b/Application/RSBot/Program.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Windows.Forms;
+using CommandLine;
+using CommandLine.Text;
 using RSBot.Core;
 using RSBot.Core.Components;
 using RSBot.Views;
+using System.Runtime.InteropServices;
 
 namespace RSBot;
 
@@ -20,19 +24,42 @@ internal static class Program
     public static string AssemblyDescription =
         Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyDescriptionAttribute>()?.Description;
 
+    public class CommandLineOptions
+    {
+        [Option('c', "character", Required = false, HelpText = "Set the character name to use.")]
+        public string Character { get; set; }
+
+        [Option('p', "profile", Required = false, HelpText = "Set the profile name to use.")]
+        public string Profile { get; set; }
+    }
+
+    private static void DisplayHelp(ParserResult<CommandLineOptions> result)
+    {
+        var helpText = HelpText.AutoBuild(result, h =>
+        {
+            h.AdditionalNewLineAfterOption = false;
+            h.AddDashesToOption = true;
+            return HelpText.DefaultParsingErrorsHandler(result, h);
+        });
+        MessageBox.Show(helpText, AssemblyTitle + " " + AssemblyVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+    }
+
     [STAThread]
     private static void Main(string[] args)
     {
-        if (args.Length == 1)
-        {
-            var profile = args[0];
-            if (ProfileManager.ProfileExists(profile))
+        var parser = new Parser(with => with.HelpWriter = Console.Out);
+        var parserResult = parser.ParseArguments<CommandLineOptions>(args);
+
+        parserResult
+            .WithParsed(options =>
             {
-                ProfileManager.SetSelectedProfile(profile);
-                ProfileManager.IsProfileLoadedByArgs = true;
-                Log.Debug($"Selected profile by args: {profile}");
-            }
-        }
+                RunOptions(options);
+            })
+            .WithNotParsed(errs =>
+            {
+                DisplayHelp(parserResult);
+                Environment.Exit(1);
+            });
 
         //CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
 
@@ -45,6 +72,34 @@ internal static class Program
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
-        Application.Run(new SplashScreen());
+
+        Main mainForm = new Main();
+        SplashScreen splashScreen = new SplashScreen(mainForm);
+        splashScreen.ShowDialog();
+
+        Application.Run(mainForm);
     }
+
+    private static void RunOptions(CommandLineOptions options)
+    {
+        if (!string.IsNullOrEmpty(options.Profile))
+        {
+            var profile = options.Profile;
+            if (ProfileManager.ProfileExists(profile))
+                ProfileManager.SetSelectedProfile(profile);
+            else
+                ProfileManager.Add(profile);
+
+            ProfileManager.IsProfileLoadedByArgs = true;
+            Log.Debug($"Selected profile by args: {profile}");
+        }
+
+        if (!string.IsNullOrEmpty(options.Character))
+        {
+            var character = options.Character;
+            ProfileManager.SelectedCharacter = character;
+            Log.Debug($"Selected character by args: {character}");
+        }
+    }
+
 }

--- a/Application/RSBot/RSBot.csproj
+++ b/Application/RSBot/RSBot.csproj
@@ -30,6 +30,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
+	  <PackageReference Include="CommandLineParser" Version="2.9.1" />
 	  <PackageReference Include="Microsoft.Net.Sdk.Compilers.Toolset" Version="9.0.300" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />

--- a/Library/RSBot.Core/Components/ProfileManager.cs
+++ b/Library/RSBot.Core/Components/ProfileManager.cs
@@ -39,6 +39,11 @@ public class ProfileManager
     public static bool IsProfileLoadedByArgs { get; set; }
 
     /// <summary>
+    ///     The selected character
+    /// </summary>
+    public static string SelectedCharacter { get; set; }
+
+    /// <summary>
     ///     The selected profile
     /// </summary>
     public static string SelectedProfile => _config.Get("RSBot.SelectedProfile", "Default");
@@ -105,6 +110,9 @@ public class ProfileManager
     /// <returns>Is created <c>true</c>; otherwise <c>false</c></returns>
     public static bool Add(string profile, bool useAsBase = false)
     {
+        if (profile.Equals("Profiles", StringComparison.InvariantCultureIgnoreCase))
+            return false;
+
         if (profile == SelectedProfile)
             return true;
 

--- a/Library/RSBot.Core/Config/GlobalConfig.cs
+++ b/Library/RSBot.Core/Config/GlobalConfig.cs
@@ -114,7 +114,7 @@ public static class GlobalConfig
 
         _config.Save();
 
-        Log.Notify("[Global] have been saved!");
+        Log.Notify("[Global] settings have been saved!");
         EventManager.FireEvent("OnSaveGlobalConfig");
     }
 }

--- a/Plugins/RSBot.General/PacketHandler/CharacterListing.cs
+++ b/Plugins/RSBot.General/PacketHandler/CharacterListing.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using RSBot.Core;
+using RSBot.Core.Components;
 using RSBot.Core.Event;
 using RSBot.Core.Network;
 using RSBot.General.Components;
@@ -119,7 +120,12 @@ internal class CharacterListing : IPacketHandler
 
         EventManager.FireEvent("OnCharacterListReceived");
 
-        if (string.IsNullOrWhiteSpace(selectedAccount.SelectedCharacter) ||
+        if (!string.IsNullOrWhiteSpace(ProfileManager.SelectedCharacter) &&
+            lobbyCharacters.Any(p => p.name == ProfileManager.SelectedCharacter))
+        {
+            selectedAccount.SelectedCharacter = ProfileManager.SelectedCharacter;
+        }
+        else if (string.IsNullOrWhiteSpace(selectedAccount.SelectedCharacter) ||
             !lobbyCharacters.Any(p => p.name == selectedAccount.SelectedCharacter))
         {
             if (charCount == 0)


### PR DESCRIPTION
Implemented a CLI parser for maintainability, moved the current profile selection to a flag. Disallowed internal config "Profiles", as the user was previously able to do it.

`-p`: Profile selection, creates the profile if not already existent. (creation might be moved to another flag to avoid confusion)
`-c`: Makes an attempt at selecting the character.
`-h`: Shows a help message of flags along with some info about current version.