### PR TITLE
Revert "GetHashCode fixed"

### DIFF
--- a/Library/RSBot.Core/Objects/Inventory/InventoryItem.cs
+++ b/Library/RSBot.Core/Objects/Inventory/InventoryItem.cs
@@ -493,6 +493,6 @@ public class InventoryItem
 
     public override int GetHashCode()
     {
-        return Record.GetHashCode();
+        throw new System.NotImplementedException();
     }
 }


### PR DESCRIPTION
Reverts SDClowen/RSBot#946 due to:
```
System.NotImplementedException: The method or operation is not implemented.
   at RSBot.Core.Objects.InventoryItem.GetHashCode() in D:\a\RSBot\RSBot\Library\RSBot.Core\Objects\Inventory\InventoryItem.cs:line 496
   at System.Collections.Generic.HashSet`1.AddIfNotPresent(T value, Int32& location)
   at System.Collections.Generic.HashSet`1.Add(T item)
   at System.Linq.Enumerable.UnionIterator`1.StoreFirst()
   at System.Linq.Enumerable.UnionIterator`1.MoveNext()
   at RSBot.Core.Objects.Player.TryGetAbilitySkills(List`1& abilitySkills) in D:\a\RSBot\RSBot\Library\RSBot.Core\Objects\Player.cs:line 1089
   at RSBot.Skills.Views.Main.LoadBuffs() in D:\a\RSBot\RSBot\Plugins\RSBot.Skills\Views\Main.cs:line 374
   at RSBot.Skills.Views.Main.LoadSkills() in D:\a\RSBot\RSBot\Plugins\RSBot.Skills\Views\Main.cs:line 474
   at RSBot.Skills.Views.Main.Filter_CheckedChanged(Object sender, EventArgs e) in D:\a\RSBot\RSBot\Plugins\RSBot.Skills\Views\Main.cs:line 894
```