### PR TITLE
Fix memory leak and heap corruption in PayloadReadString

### DIFF
--- a/Library/RSBot.Loader.Library/Library.cpp
+++ b/Library/RSBot.Loader.Library/Library.cpp
@@ -137,6 +137,9 @@ int WINAPI Detour_connect(SOCKET s, const struct sockaddr* name, int len)
 
 	for (auto& gatewayAddress : g_RealGatewayAddresses)
 	{
+		struct hostent* remoteHost = gethostbyname(gatewayAddress.c_str());
+		if (remoteHost == NULL || remoteHost->h_addr_list[0] == NULL) continue;
+
 		struct in_addr maddr = { 0 };
 		maddr.s_addr = *(u_long*)gethostbyname(gatewayAddress.c_str())->h_addr_list[0];
 		if (strcmp(inet_ntoa(editing->sin_addr), inet_ntoa(maddr)) == 0 && htons(editing->sin_port) == g_RealGatewayPort)

--- a/Library/RSBot.Loader.Library/PayloadHelper.h
+++ b/Library/RSBot.Loader.Library/PayloadHelper.h
@@ -16,11 +16,13 @@ void PayloadReadString(ifstream& stream, string& dst)
 	int nLength;
 	PayloadRead(stream, nLength);
 
-	char* buffer = (char*)malloc(nLength);
-	stream.read(buffer, nLength);
-	buffer[nLength] = '\0';
-
-	dst = string(buffer);
+	if (nLength > 0) 
+	{
+		dst.resize(nLength);
+		stream.read(&dst[0], nLength);
+	}
+	else
+		dst = "";
 }
 
 template <typename T>


### PR DESCRIPTION
Refactored the `PayloadReadString` function to use `std::string::resize` instead of `malloc`.

This fixes:
- A memory leak (malloc was never freed).
- Potential heap corruption (writing null terminator out of bounds).

---
Special thanks to @ilkerbrz for this project!